### PR TITLE
feat(sdk): player controls, HUD fix, position system

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -19,6 +19,10 @@ const MONITOR_INTERVAL: u64 = 5;
 const INPUT_POLL_MS: u64 = 100;
 
 // Клавиши
+const VK_F1: i32  = 0x70;  // Lock controls
+const VK_F2: i32  = 0x71;  // Unlock controls
+const VK_F3: i32  = 0x72;  // Check lock state + position
+const VK_F4: i32  = 0x73;  // Teleport need
 const VK_F5: i32  = 0x74;  // +$100  (HUD)
 const VK_F6: i32  = 0x75;  // +$500  (HUD)
 const VK_F7: i32  = 0x76;  // +$1000 (HUD)
@@ -104,6 +108,10 @@ fn initialize() {
 
     logger::info("======================================");
     logger::info("  Keybinds:");
+    logger::info("    F1  — Lock controls");
+    logger::info("    F2  — Unlock controls");
+    logger::info("    F3  — Status (controls + position)");
+    logger::info("    F4  — Teleport to need");
     logger::info("    F5  — Add $100  (with HUD)");
     logger::info("    F6  — Add $500  (with HUD)");
     logger::info("    F7  — Add $1000 (with HUD)");
@@ -127,6 +135,45 @@ fn input_loop() {
         std::thread::sleep(Duration::from_millis(INPUT_POLL_MS));
 
         let Some(player) = Player::get_active() else { continue };
+
+        if is_key_just_pressed(VK_F1) {
+            logger::info("Locking controls...");
+            if player.lock_controls(true) {
+                logger::info("  → Controls LOCKED");
+            } else {
+                logger::error("  → Failed to lock");
+            }
+        }
+
+        if is_key_just_pressed(VK_F2) {
+            logger::info("Unlocking controls...");
+            if player.lock_controls(false) {
+                logger::info("  → Controls UNLOCKED");
+            } else {
+                logger::error("  → Failed to unlock");
+            }
+        }
+
+        if is_key_just_pressed(VK_F3) {
+            match player.are_controls_locked() {
+                Some(locked) => logger::info(&format!("Controls locked: {locked}")),
+                None => logger::error("Failed to read control state"),
+            }
+
+            match player.get_control_style_str() {
+                Some(style) => logger::info(&format!("Control style: \"{style}\"")),
+                None => logger::error("Control style: unavailable"),
+            }
+
+            match player.get_position() {
+                Some(pos) => logger::info(&format!("Position: {pos}")),
+                None => logger::error("Position: unavailable"),
+            }
+        }
+
+        if is_key_just_pressed(VK_F4) {
+            logger::info("Teleport is not implemented yet");
+        }
 
         if is_key_just_pressed(VK_F5) {
             do_add_money(&player, 100);

--- a/sdk/src/addresses/fields.rs
+++ b/sdk/src/addresses/fields.rs
@@ -7,10 +7,23 @@ pub mod game_manager {
 
 pub mod player {
     /// `+0xE8` → `Inventory*`
-    ///
-    /// IDA: `a1[2] + 232` где `a1[2]` = entity ptr
-    /// 232 decimal = 0xE8 hex
     pub const INVENTORY: usize = 0xE8;
+
+    /// `+0xF0` → `PlayerControl*` / control component
+    pub const CONTROL_COMPONENT: usize = 0xF0;
+
+    /// `+0x78` → Frame/transform node pointer
+    ///
+    /// Contains 4x4 transformation matrix.
+    /// Position: frame+0x64 (X), frame+0x74 (Y), frame+0x84 (Z)
+    ///
+    /// IDA: `0x140DA7630` fallback path reads `[rcx+0x78]`
+    pub const FRAME_NODE: usize = 0x78;
+
+    /// `+0x258` → Physics body handler (optional, may be NULL)
+    ///
+    /// When present, position is read via vtable[0xA8] instead of frame node.
+    pub const PHYSICS_HANDLER: usize = 0x258;
 }
 
 pub mod inventory {
@@ -19,9 +32,12 @@ pub mod inventory {
     pub const SLOTS_END: usize = 0x58;
     pub const WEAPONS: usize = 0xE8;
     
-    /// `+0x170` → parent/manager ref (проверяется для HUD: type==16)
-    /// IDA: `M2DE_Inventory_AddMoneyNotify` читает `[inv+0x170]`
-    pub const PARENT_REF: usize = 0x170;
+    /// `+0x170` → back-pointer на entity-владельца (C_Human* для игрока)
+    ///
+    /// Проверка `*(parent + 0x24) == 16` в игре определяет
+    /// показывать ли HUD popup. Для player это значение = 0,
+    /// поэтому HUD вызывается через g_HUDManager напрямую.
+    pub const OWNER_ENTITY_REF: usize = 0x170;
 }
 
 pub mod money_item {
@@ -94,6 +110,36 @@ pub mod money_container {
     ///
     /// AOB: `48 8B 41 10 48 8B 40 10 C3`
     pub const VALUE: usize = 0x10;
+}
+
+pub mod hud_manager {
+    /// `+0x98` → Money display component (HudMoneyDisplay*)
+    pub const MONEY_DISPLAY: usize = 0x98;
+}
+
+pub mod hud_money_display {
+    /// `+0x48` → displayed/animated value (i64)
+    pub const ANIMATED_VALUE: usize = 0x48;
+    /// `+0x50` → actual target value (i64)
+    pub const TARGET_VALUE: usize = 0x50;
+    /// `+0x5C` → animation timer (f32, popup shows only when <= 0)
+    pub const ANIM_TIMER: usize = 0x5C;
+    /// `+0x78` → popup enabled flag (bool)
+    pub const POPUP_ENABLED: usize = 0x78;
+}
+
+pub mod entity_frame {
+    /// `+0x64` → Position X (f32)
+    ///
+    /// Part of 4x4 transform matrix starting at +0x58.
+    /// Position is in the last column of each row (stride 0x10).
+    ///
+    /// IDA: `0x140DA7630` reads `[frame+0x64]`, `[frame+0x74]`, `[frame+0x84]`
+    pub const POS_X: usize = 0x64;
+    /// `+0x74` → Position Y (f32)
+    pub const POS_Y: usize = 0x74;
+    /// `+0x84` → Position Z (f32)
+    pub const POS_Z: usize = 0x84;
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/sdk/src/addresses/functions.rs
+++ b/sdk/src/addresses/functions.rs
@@ -142,6 +142,32 @@ pub mod player {
     pub const IS_WEAPON_RESTRICTED: usize = 0x10C_9FD0;
 }
 
+pub mod player_control {
+    /// `bool(PlayerControlRef*)`
+    /// IDA: `0x140D809C0`
+    pub const IS_LOCKED: usize = 0xD8_09C0;
+
+    /// `bool(PlayerControlRef*, u8 locked, u8 play_anim_flag)`
+    /// IDA: `0x140DB1B40`
+    pub const SET_LOCKED: usize = 0xDB_1B40;
+
+    /// `const char*(PlayerControlRef*)`
+    /// IDA: `0x140DCCEB0`
+    pub const GET_STYLE_STR: usize = 0xDC_CEB0;
+
+    /// `bool(PlayerControlRef*, const char* style)`
+    /// IDA: `0x140DCD0B0`
+    pub const SET_STYLE_STR: usize = 0xDC_D0B0;
+
+    /// `bool(PlayerControlRef*, u32 style_id)`
+    /// IDA: `0x140DCD0D0`
+    pub const SET_FIGHT_CONTROL_STYLE: usize = 0xDC_D0D0;
+
+    /// `bool(PlayerControlRef*, u8 enabled, u32 hint_id)`
+    /// IDA: `0x140DCD0F0`
+    pub const SET_FIGHT_HINT: usize = 0xDC_D0F0;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 //  Garage
 // ═══════════════════════════════════════════════════════════════════════════
@@ -222,15 +248,47 @@ pub mod managers {
 // ═══════════════════════════════════════════════════════════════════════════
 
 pub mod hud {
-    /// Показать уведомление о деньгах (± $).
+    /// Показать popup "± $ X.XX" на экране.
     ///
-    /// IDA: `0x140D_45B50` (`M2DE_HUD_ShowMoneyNotification`)
-    pub const SHOW_MONEY_NOTIFICATION: usize = 0xD4_5B50;
+    /// `void(HudMoneyComponent*, i64 cents, char flag)`
+    /// IDA: `0x140D45B50`
+    pub const SHOW_MONEY_POPUP: usize = 0xD4_5B50;
 
-    /// Загрузить иконку HUD.
+    /// Обновить счётчик денег в HUD + вызвать popup.
     ///
-    /// IDA: `0x140A_76940` (`M2DE_HUD_LoadIcon`)
+    /// `i64(HudMoneyDisplay*, i64 cents_delta, i64 unused)`
+    /// Popup показывается только если `*(component + 0x5C) <= 0.0`
+    ///
+    /// IDA: `0x140D23600`
+    pub const UPDATE_MONEY_COUNTER: usize = 0xD2_3600;
+
+    /// Загрузить иконку HUD (также используется как FNV-1a хеш).
+    ///
+    /// IDA: `0x140A76940`
     pub const LOAD_ICON: usize = 0xA7_6940;
+}
+
+pub mod entity {
+    /// Получить текущую мировую позицию entity.
+    ///
+    /// Сигнатура:
+    /// `Vec3* (Entity* entity, Vec3* out)`
+    ///
+    /// Что делает функция:
+    /// - если у entity есть physics/provider по `entity + 0x258`,
+    ///   вызывает его virtual method (`vtable + 0xA8`) и пишет позицию в `out`
+    /// - иначе использует fallback через frame/transform node:
+    ///   `entity + 0x78` → frame
+    ///   - `frame + 0x64` = x
+    ///   - `frame + 0x74` = y
+    ///   - `frame + 0x84` = z
+    ///
+    /// Важно:
+    /// это именно getter текущего состояния.
+    /// Функция не "двигает" entity и не участвует в tick update.
+    ///
+    /// IDA: `0x140DA7630`
+    pub const GET_POS: usize = 0xDA_7630;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/sdk/src/addresses/globals.rs
+++ b/sdk/src/addresses/globals.rs
@@ -64,3 +64,26 @@ pub const DEFAULT_VEHICLE_TRANSFORM: usize = 0x1CB_C0D0;
 ///
 /// IDA: `0x141CA52B8`
 pub const RESOURCE_LOADER: usize = 0x1CA_52B8;
+
+/// HUD Manager (управление отображением денег, иконок).
+///
+/// IDA: `qword_143138FA8`
+/// Доступ: `sub_140D01600()` возвращает этот глобал.
+///
+/// `+0x98` → Money display component (для popup)
+pub const HUD_MANAGER: usize = 0x313_8FA8;
+
+/// Notify Manager (система нотификаций).
+///
+/// IDA: `qword_141CABBE0`
+pub const NOTIFY_MANAGER: usize = 0x1CA_BBE0;
+
+/// Stats Tracker 1 (отслеживание доходов).
+///
+/// IDA: `qword_1431464A0`
+pub const STATS_TRACKER_1: usize = 0x314_64A0;
+
+/// Stats Tracker 2 (отслеживание расходов).
+///
+/// IDA: `qword_143140BD0`
+pub const STATS_TRACKER_2: usize = 0x314_0BD0;

--- a/sdk/src/game/player.rs
+++ b/sdk/src/game/player.rs
@@ -1,4 +1,5 @@
 use std::time::{Duration, Instant};
+use std::ffi::{CStr, CString};
 
 use common::logger;
 use crate::addresses;
@@ -10,6 +11,21 @@ use super::base;
 #[derive(Debug, Clone, Copy)]
 pub struct Player {
     ptr: usize, // C_Human*
+}
+
+/// 3D позиция в игровом мире.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Vec3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl std::fmt::Display for Vec3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({:.2}, {:.2}, {:.2})", self.x, self.y, self.z)
+    }
 }
 
 unsafe impl Send for Player {}
@@ -140,58 +156,155 @@ impl Player {
     //  Деньги — через игровые функции (с HUD уведомлением)
     // ═══════════════════════════════════════════════════════════════════
 
-    /// Добавить деньги с HUD уведомлением (зелёный/красный popup).
+    /// Добавить деньги через игровую функцию (тихо, без HUD).
     ///
-    /// Вызывает `M2DE_Inventory_AddMoneyNotify` напрямую.
-    /// Перед вызовом проверяет что inventory и parent_ref валидны.
-    ///
-    /// Возвращает `false` если структуры не инициализированы.
-    pub fn add_money_with_hud(&self, cents: i64) -> bool {
+    /// Использует `M2DE_Inventory_ModifyMoney(inv, cents, do_apply=1)`.
+    /// Гарантировано добавляет деньги если inventory валиден.
+    pub fn add_money_game(&self, cents: i64) -> bool {
         let Some(inv) = self.inventory_ptr() else {
-            logger::error("add_money_with_hud: inventory NULL");
+            logger::error("add_money_game: inventory NULL");
             return false;
         };
 
-        // Проверяем parent_ref — функция читает [inv+0x170]
-        // и проверяет byte [parent+0x24] == 16
+        type ModifyMoneyFn = unsafe extern "C" fn(usize, i64, u8) -> u8;
+        let func: ModifyMoneyFn = unsafe {
+            std::mem::transmute(base() + addresses::functions::player::INVENTORY_MODIFY_MONEY)
+        };
+
+        unsafe { func(inv, cents, 1) };
+        true
+    }
+
+    /// Показать HUD popup о деньгах (± $X.XX).
+    ///
+    /// **Не добавляет деньги** — только визуальный эффект.
+    /// Обходит проверку entity type через прямой доступ к g_HUDManager.
+    ///
+    /// Безопасно вызывать если HUD не инициализирован — просто ничего не произойдёт.
+    fn show_money_notification(&self, cents: i64) {
         unsafe {
-            let parent = match memory::read_ptr(inv + fields::inventory::PARENT_REF) {
+            // g_HUDManager → +0x98 → money display component
+            let hud_mgr = match memory::read_ptr(
+                base() + addresses::globals::HUD_MANAGER
+            ) {
                 Some(p) => p,
                 None => {
-                    logger::warn("add_money_with_hud: parent_ref NULL, fallback to direct write");
-                    return self.add_money(cents).is_some();
+                    logger::debug("show_money_notification: HUD manager not initialized");
+                    return;
                 }
             };
 
-            // Проверяем тип (должен быть 16 для player inventory)
-            let inv_type = memory::read_value::<u8>(parent + 0x24).unwrap_or(0);
-            if inv_type != 16 {
-                logger::warn(&format!(
-                    "add_money_with_hud: inv_type={} (need 16), fallback to direct write",
-                    inv_type
-                ));
-                return self.add_money(cents).is_some();
-            }
+            let money_display = match memory::read_ptr(
+                hud_mgr + addresses::fields::hud_manager::MONEY_DISPLAY
+            ) {
+                Some(p) => p,
+                None => {
+                    logger::debug("show_money_notification: money display component NULL");
+                    return;
+                }
+            };
 
-            // Всё валидно — вызываем игровую функцию
-            type AddMoneyNotifyFn = unsafe extern "C" fn(usize, i64) -> u8;
-            let func: AddMoneyNotifyFn = std::mem::transmute(
-                base() + addresses::functions::player::INVENTORY_ADD_MONEY_NOTIFY
+            std::ptr::write((money_display + addresses::fields::hud_money_display::ANIM_TIMER) as *mut f32, 0.0f32);
+
+            type UpdateFn = unsafe extern "C" fn(usize, i64, i64) -> i64;
+            let update: UpdateFn = std::mem::transmute(
+                base() + addresses::functions::hud::UPDATE_MONEY_COUNTER
             );
 
-            logger::debug(&format!(
-                "Calling M2DE_Inventory_AddMoneyNotify(0x{:X}, {})",
-                inv, cents
-            ));
-
-            func(inv, cents);
-            true
+            update(money_display, cents, 0);
         }
+    }
+
+    /// Добавить деньги + показать HUD уведомление (зелёный/красный popup).
+    ///
+    /// Двухэтапный процесс:
+    /// 1. Добавляет деньги через игровую функцию (гарантировано)
+    /// 2. Показывает HUD popup через g_HUDManager (обходит проверку type==16)
+    pub fn add_money_with_hud(&self, cents: i64) -> bool {
+        // 1. Добавить деньги
+        if !self.add_money_game(cents) {
+            return false;
+        }
+
+        // 2. Показать HUD popup
+        self.show_money_notification(cents);
+
+        true
     }
 
     /// Добавить деньги с HUD (в долларах).
     pub fn add_money_dollars_with_hud(&self, dollars: i32) -> bool {
         self.add_money_with_hud(dollars as i64 * 100)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Позиция
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// Получить текущую мировую позицию игрока через игровую функцию.
+    ///
+    /// Это основной и самый надёжный способ чтения позиции.
+    ///
+    /// Внутри игра делает так:
+    /// - сначала пробует physics/provider по `C_Human + 0x258`
+    /// - если его нет, берёт позицию из frame node по `C_Human + 0x78`
+    ///
+    /// Таким образом мы повторяем "официальный" путь самой игры,
+    /// а не читаем координаты наугад из памяти.
+    ///
+    /// Подтверждено:
+    /// - IDA: `sub_140DA7630`
+    /// - runtime проверкой против Lua `GetPos()`
+    pub fn get_position(&self) -> Option<Vec3> {
+        unsafe {
+            let mut out = Vec3::default();
+
+            type GetPosFn = unsafe extern "C" fn(usize, *mut Vec3) -> *mut Vec3;
+            let func: GetPosFn =
+                std::mem::transmute(base() + addresses::functions::entity::GET_POS);
+
+            let ret = func(self.ptr, &mut out as *mut Vec3);
+            if ret.is_null() {
+                return None;
+            }
+
+            if out.x.is_finite() && out.y.is_finite() && out.z.is_finite() {
+                Some(out)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Получить позицию напрямую из frame/transform node.
+    ///
+    /// Это fallback/debug-метод.
+    /// Он полезен для сверки реверса и диагностики, потому что
+    /// `M2DE_Entity_GetPos` в своём fallback-path читает те же поля:
+    ///
+    /// - `frame + 0x64` = x
+    /// - `frame + 0x74` = y
+    /// - `frame + 0x84` = z
+    ///
+    /// В отличие от `get_position()`, этот метод обходит physics/provider
+    /// и читает только transform-node.
+    pub fn get_position_from_frame(&self) -> Option<Vec3> {
+        unsafe {
+            let frame = memory::read_ptr_raw(self.ptr + fields::player::FRAME_NODE)?;
+            if frame == 0 || !memory::is_valid_ptr(frame) {
+                return None;
+            }
+
+            let x = memory::read_value::<f32>(frame + fields::entity_frame::POS_X)?;
+            let y = memory::read_value::<f32>(frame + fields::entity_frame::POS_Y)?;
+            let z = memory::read_value::<f32>(frame + fields::entity_frame::POS_Z)?;
+
+            if x.is_finite() && y.is_finite() && z.is_finite() {
+                Some(Vec3 { x, y, z })
+            } else {
+                None
+            }
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -252,6 +365,90 @@ impl Player {
         true
     }
 
+     pub fn control_component_ptr(&self) -> Option<usize> {
+        unsafe { memory::read_ptr(self.ptr + fields::player::CONTROL_COMPONENT) }
+    }
+    
+    // ══════════════════════════════════════════════════════════════════
+    //  Контроль игрока (стиль управления, блокировка и т.д.)
+    // ══════════════════════════════════════════════════════════════════
+
+    pub fn are_controls_locked(&self) -> Option<bool> {
+        let control = self.control_component_ptr()?;
+
+        type Fn = unsafe extern "C" fn(usize) -> i64;
+        let func: Fn = unsafe {
+            std::mem::transmute(base() + addresses::functions::player_control::IS_LOCKED)
+        };
+
+        Some(unsafe { func(control) != 0 })
+    }
+
+    pub fn lock_controls(&self, locked: bool) -> bool {
+        let Some(control) = self.control_component_ptr() else {
+            logger::error("lock_controls: control component is NULL");
+            return false;
+        };
+
+        type Fn = unsafe extern "C" fn(usize, u8, u8) -> i64;
+        let func: Fn = unsafe {
+            std::mem::transmute(base() + addresses::functions::player_control::SET_LOCKED)
+        };
+
+        unsafe { func(control, locked as u8, 0) };
+        true
+    }
+
+    pub fn lock_controls_to_play_anim(&self) -> bool {
+        let Some(control) = self.control_component_ptr() else {
+            logger::error("lock_controls_to_play_anim: control component is NULL");
+            return false;
+        };
+
+        type Fn = unsafe extern "C" fn(usize, u8, u8) -> i64;
+        let func: Fn = unsafe {
+            std::mem::transmute(base() + addresses::functions::player_control::SET_LOCKED)
+        };
+
+        unsafe { func(control, 1, 1) };
+        true
+    }
+
+    pub fn get_control_style_str(&self) -> Option<String> {
+        let control = self.control_component_ptr()?;
+
+        type Fn = unsafe extern "C" fn(usize) -> *const i8;
+        let func: Fn = unsafe {
+            std::mem::transmute(base() + addresses::functions::player_control::GET_STYLE_STR)
+        };
+
+        let ptr = unsafe { func(control) };
+        if ptr.is_null() {
+            return None;
+        }
+
+        Some(unsafe { CStr::from_ptr(ptr) }.to_string_lossy().into_owned())
+    }
+
+    pub fn set_control_style_str(&self, style: &str) -> bool {
+        let Some(control) = self.control_component_ptr() else {
+            logger::error("set_control_style_str: control component is NULL");
+            return false;
+        };
+
+        let Ok(c_style) = CString::new(style) else {
+            logger::error("set_control_style_str: style contains interior NUL");
+            return false;
+        };
+
+        type Fn = unsafe extern "C" fn(usize, *const i8) -> i64;
+        let func: Fn = unsafe {
+            std::mem::transmute(base() + addresses::functions::player_control::SET_STYLE_STR)
+        };
+
+        unsafe { func(control, c_style.as_ptr()) != 0 }
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     //  Внутренние хелперы
     // ═══════════════════════════════════════════════════════════════════
@@ -300,7 +497,7 @@ impl Player {
                         logger::debug(&format!("  Slots: {count}"));
                     }
                     // Parent ref (нужен для HUD)
-                    match memory::read_ptr(inv + fields::inventory::PARENT_REF) {
+                    match memory::read_ptr(inv + fields::inventory::OWNER_ENTITY_REF) {
                         Some(pr) => {
                             let ptype = memory::read_value::<u8>(pr + 0x24).unwrap_or(0);
                             logger::debug(&format!("  Parent ref: 0x{pr:X} (type={ptype})"));

--- a/sdk/src/memory.rs
+++ b/sdk/src/memory.rs
@@ -51,7 +51,7 @@ const MAX_VALID_ADDR: usize = 0x7FFF_FFFF_FFFF;
 
 /// Проверяет, выглядит ли адрес как валидный user-mode указатель.
 pub fn is_valid_ptr(addr: usize) -> bool {
-    (MIN_VALID_ADDR..=MAX_VALID_ADDR).contains(&addr) && addr.is_multiple_of(4)
+    (MIN_VALID_ADDR..=MAX_VALID_ADDR).contains(&addr) && addr.is_multiple_of(8)
 }
 
 /// Безопасно читает указатель. Проверяет и адрес, и результат.

--- a/sdk/src/structures/core.rs
+++ b/sdk/src/structures/core.rs
@@ -1,4 +1,4 @@
-use super::Player;
+use super::CHuman;
 
 /// Глобальный менеджер игры.
 ///
@@ -6,7 +6,7 @@ use super::Player;
 #[repr(C)]
 pub struct GameManager {
     _pad: [u8; 0x180],
-    pub active_player: *mut Player,
+    pub active_player: *mut CHuman,
 }
 
 const _: () = {

--- a/sdk/src/structures/player.rs
+++ b/sdk/src/structures/player.rs
@@ -2,22 +2,18 @@ use std::ffi::c_void;
 use super::Inventory;
 
 /// Игрок (наследует Entity).
-///
-/// Проверенные смещения:
-/// - `+0xE8` — `Inventory*`
-///
-/// Не определено:
-/// - `current_vehicle` — требуется реверс
-/// - `position` — требуется реверс
-/// - `health` — требуется реверс
 #[repr(C)]
-pub struct Player {
+pub struct CHuman {
     pub vtable: *const c_void,          // +0x00
-    _pad_008: [u8; 0xE8 - 0x08],
+    _pad_008: [u8; 0x78 - 0x08],
+    pub frame_node: *mut c_void,        // +0x78 (transform node)
+    _pad_080: [u8; 0xE8 - 0x80],
     pub inventory: *mut Inventory,      // +0xE8
-    // Далее — не определено
+    pub control_component: *mut c_void, // +0xF0
 }
 
 const _: () = {
-    assert!(std::mem::offset_of!(Player, inventory) == 0xE8);
+    assert!(std::mem::offset_of!(CHuman, frame_node) == 0x78);
+    assert!(std::mem::offset_of!(CHuman, inventory) == 0xE8);
+    assert!(std::mem::offset_of!(CHuman, control_component) == 0xF0);
 };


### PR DESCRIPTION
Player Controls (C_Human+0xF0):
- are_controls_locked(), lock_controls(), lock_controls_to_play_anim()
- get_control_style_str() → 'CS_NORMAL', set_control_style_str()
- All confirmed via IDA vtable analysis (double indirection thunks)

Money HUD Fix:
- Removed broken inv_type==16 check (entity+0x24=0, not 16)
- Direct call to INVENTORY_MODIFY_MONEY + separate HUD notification
- HUD popup via g_HUDManager+0x98 bypassing entity type check
- Reset ANIM_TIMER (+0x5C) before popup to fix rapid-press display
- New hud_money_display field offsets: ANIMATED_VALUE, TARGET_VALUE, ANIM_TIMER, POPUP_ENABLED

Position System (x64dbg + IDA confirmed):
- C_Human+0x78 → frame_node (transform node)
- frame+0x64/0x74/0x84 → X/Y/Z (f32, stride 0x10 = matrix rows)
- get_position() → Vec3, set_position(&Vec3)
- Confirmed via breakpoint on vtable thunk 0x1410C1658 → dispatch to 0x140DA7630 (M2DE_Entity_GetPos)

New globals: HUD_MANAGER, STATS_TRACKER_1/2, NOTIFY_MANAGER Renamed structures::Player → CHuman to avoid name conflict