### PR TITLE
feat(sdk): add engine-level player position setter

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -172,7 +172,19 @@ fn input_loop() {
         }
 
         if is_key_just_pressed(VK_F4) {
-            logger::info("Teleport is not implemented yet");
+            match player.get_position() {
+                Some(mut pos) => {
+                    logger::info(&format!("Current position: {pos}"));
+                    pos.z += 10.0;
+
+                    if player.set_position(&pos) {
+                        logger::info(&format!("Teleported to: {pos}"));
+                    } else {
+                        logger::error("Teleport failed");
+                    }
+                }
+                None => logger::error("Position unavailable"),
+            }
         }
 
         if is_key_just_pressed(VK_F5) {

--- a/sdk/src/addresses/functions.rs
+++ b/sdk/src/addresses/functions.rs
@@ -289,6 +289,29 @@ pub mod entity {
     ///
     /// IDA: `0x140DA7630`
     pub const GET_POS: usize = 0xDA_7630;
+
+    /// `void(Entity*, const Vec3*)` — установить мировую позицию entity.
+    ///
+    /// Это high-level setter движка:
+    /// - пишет позицию в frame node
+    /// - синкает physics (`entity + 0x258`) если есть
+    /// - обновляет вспомогательные transform/cache структуры
+    /// - выставляет dirty/invalid flags
+    ///
+    /// Цепочка подтверждения:
+    /// `Lua SetPos -> wrapper thunk -> wrapper impl (0x1410ADC60)
+    ///  -> entity vtable +0x100 -> thunk 0x1400C9950 -> this function`
+    ///
+    /// IDA: `0x140DD1000`
+    pub const SET_POS: usize = 0xDD_1000;
+
+    /// Низкоуровневая запись позиции только в frame/transform node.
+    ///
+    /// Обычно напрямую вызывать не нужно.
+    /// Для SDK предпочтителен `SET_POS`, так как он обновляет и другие подсистемы.
+    ///
+    /// IDA: `0x1403B9660`
+    pub const SET_POS_RAW: usize = 0x3B_9660;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/sdk/src/game/player.rs
+++ b/sdk/src/game/player.rs
@@ -276,18 +276,18 @@ impl Player {
         }
     }
 
-    /// Получить позицию напрямую из frame/transform node.
+    /// Прямое чтение позиции из frame/transform node.
     ///
-    /// Это fallback/debug-метод.
-    /// Он полезен для сверки реверса и диагностики, потому что
-    /// `M2DE_Entity_GetPos` в своём fallback-path читает те же поля:
+    /// Это debug/fallback-метод.
+    /// Он полезен для сверки реверса, потому что `M2DE_Entity_GetPos`
+    /// в fallback-path читает те же поля:
     ///
     /// - `frame + 0x64` = x
     /// - `frame + 0x74` = y
     /// - `frame + 0x84` = z
     ///
-    /// В отличие от `get_position()`, этот метод обходит physics/provider
-    /// и читает только transform-node.
+    /// По факту это и есть реальные world coordinates, что было подтверждено
+    /// сравнением с Lua `GetPos()`.
     pub fn get_position_from_frame(&self) -> Option<Vec3> {
         unsafe {
             let frame = memory::read_ptr_raw(self.ptr + fields::player::FRAME_NODE)?;
@@ -304,6 +304,32 @@ impl Player {
             } else {
                 None
             }
+        }
+    }
+
+    /// Установить мировую позицию игрока через штатный engine-level setter.
+    ///
+    /// Почему так, а не прямой записью в память:
+    /// игра хранит позицию не только в одном месте. Помимо frame node,
+    /// при перемещении обновляются physics и внутренние dirty/cached state.
+    ///
+    /// Поэтому используется `M2DE_Entity_SetPos`, который делает полный
+    /// корректный путь обновления движка.
+    ///
+    /// Возвращает `false`, если переданы некорректные координаты.
+    pub fn set_position(&self, pos: &Vec3) -> bool {
+        if !pos.x.is_finite() || !pos.y.is_finite() || !pos.z.is_finite() {
+            logger::error("set_position: non-finite coordinate");
+            return false;
+        }
+
+        unsafe {
+            type SetPosFn = unsafe extern "C" fn(usize, *const Vec3);
+            let func: SetPosFn =
+                std::mem::transmute(base() + addresses::functions::entity::SET_POS);
+
+            func(self.ptr, pos as *const Vec3);
+            true
         }
     }
 


### PR DESCRIPTION
Add confirmed M2DE_Entity_SetPos path from Lua wrapper -> entity vtable. Position updates now use engine-level setter instead of raw transform writes, keeping physics and internal state in sync.