### PR TITLE
feat(sdk): add DX11 render device and swapchain reverse data

### DIFF
--- a/sdk/src/addresses/data.rs
+++ b/sdk/src/addresses/data.rs
@@ -1,0 +1,55 @@
+//! RVA адресов важных data/IID объектов в памяти игры.
+
+pub mod render_iids {
+    /// `IID_IDXGIFactory4`
+    ///
+    /// Используется в `M2DE_CreateSwapChain`.
+    ///
+    /// IDA: `0x1418A38A0`
+    pub const IDXGI_FACTORY4: usize = 0x18A_38A0;
+
+    /// `IID_ID3D11Texture2D`
+    ///
+    /// Используется в `IDXGISwapChain1::GetBuffer(0, IID_ID3D11Texture2D, ...)`.
+    ///
+    /// IDA: `0x1418A38B0`
+    pub const ID3D11_TEXTURE2D: usize = 0x18A_38B0;
+
+    /// `IID_IDXGIFactory1`
+    ///
+    /// Используется в `CreateDXGIFactory1` и `GetParent`.
+    ///
+    /// IDA: `0x1418A4638`
+    pub const IDXGI_FACTORY1: usize = 0x18A_4638;
+
+    /// `IID_ID3DUserDefinedAnnotation`
+    ///
+    /// Используется для query у immediate context.
+    ///
+    /// IDA: `0x1418A4648`
+    pub const ID3D_USER_DEFINED_ANNOTATION: usize = 0x18A_4648;
+
+    /// `IID_IDXGIDevice`
+    ///
+    /// IDA: `0x1418A4658`
+    pub const IDXGI_DEVICE: usize = 0x18A_4658;
+
+    /// `IID_IDXGIAdapter1`
+    ///
+    /// IDA: `0x1418A4668`
+    pub const IDXGI_ADAPTER1: usize = 0x18A_4668;
+
+    /// `IID_IDXGIFactory5`
+    ///
+    /// Нужен для `CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING)`.
+    ///
+    /// IDA: `0x1418A4AF8`
+    pub const IDXGI_FACTORY5: usize = 0x18A_4AF8;
+}
+
+pub mod render_data {
+    /// Значение blend-factor, используемое при initial setup.
+    ///
+    /// IDA: `0x141856A80`
+    pub const DEFAULT_BLEND_FACTOR: usize = 0x185_6A80;
+}

--- a/sdk/src/addresses/fields.rs
+++ b/sdk/src/addresses/fields.rs
@@ -211,3 +211,161 @@ pub mod callback_entry {
     pub const CONTEXT: usize = 0x30;
     pub const SIZE: usize = 64;
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+//  RenderDevice и swapchain (новые)
+// ═══════════════════════════════════════════════════════════════════════
+
+pub mod render_device {
+    /// `+0x2008` → начало блока init-параметров рендера.
+    ///
+    /// Внутри этого блока лежат:
+    /// - `+0x18` от блока → текущая ширина
+    /// - `+0x1C` от блока → текущая высота
+    /// - `+0x20` от блока → указатель на window/config структуру
+    pub const INIT_CONFIG: usize = 0x2008;
+
+    /// `+0x2020` → текущая ширина рендера.
+    ///
+    /// Поле обновляется и в recreate/resize path.
+    pub const RENDER_WIDTH: usize = 0x2020;
+
+    /// `+0x2024` → текущая высота рендера.
+    pub const RENDER_HEIGHT: usize = 0x2024;
+
+    /// `+0x2028` → указатель на window/config структуру из init params.
+    pub const WINDOW_CONFIG_PTR: usize = 0x2028;
+
+    /// `+0x2032` → поддержка feature level 10.0.
+    pub const SUPPORTS_FL_10_0: usize = 0x2032;
+
+    /// `+0x2033` → дополнительный флаг поддержки FL10.0.
+    pub const SUPPORTS_FL_10_0_DUP: usize = 0x2033;
+
+    /// `+0x2034` → поддержка feature level 10.1.
+    pub const SUPPORTS_FL_10_1: usize = 0x2034;
+
+    /// `+0x2035` → флаг завершённой DX-инициализации.
+    pub const DX_INITIALIZED: usize = 0x2035;
+
+    /// `+0x203C` → количество выходов текущего адаптера.
+    pub const ADAPTER_OUTPUT_COUNT: usize = 0x203C;
+
+    /// `+0x2040` → максимальный размер текстур.
+    pub const MAX_TEXTURE_SIZE: usize = 0x2040;
+
+    /// `+0x2044` → настройка фильтрации / aniso-related state.
+    pub const ANISO_FILTER_SETTING: usize = 0x2044;
+
+    /// `+0x2050` → shader/resource cache из базового конструктора.
+    pub const SHADER_CACHE: usize = 0x2050;
+
+    /// `+0x2070` → dynamic vertex buffer resource.
+    ///
+    /// Строка: `"RenderDeviceBase::DynamicVB"`
+    pub const DYNAMIC_VB: usize = 0x2070;
+
+    /// `+0x2078` → dynamic index buffer resource.
+    ///
+    /// Строка: `"RenderDeviceBase::DynamicIB"`
+    pub const DYNAMIC_IB: usize = 0x2078;
+
+    /// `+0x21A8` → текущий режим/профиль рендера.
+    ///
+    /// Используется в switch внутри init.
+    pub const CURRENT_STATE_MODE: usize = 0x21A8;
+
+    /// `+0x21AC` → вторичный state mode.
+    pub const CURRENT_STATE_MODE_B: usize = 0x21AC;
+
+    /// `+0x2780` → `IDXGIFactory1*`
+    pub const DXGI_FACTORY: usize = 0x2780;
+
+    /// `+0x2788` → `D3D_FEATURE_LEVEL`
+    pub const FEATURE_LEVEL: usize = 0x2788;
+
+    /// `+0x2790` → `ID3D11Device*`
+    pub const D3D_DEVICE: usize = 0x2790;
+
+    /// `+0x2798` → `ID3D11DeviceContext*`
+    pub const D3D_CONTEXT: usize = 0x2798;
+
+    /// `+0x27A0` → `M2DE_SwapChainManager*`
+    pub const SWAPCHAIN_MANAGER: usize = 0x27A0;
+
+    /// `+0x27A8` → `M2DE_SwapChainWrapper*`
+    ///
+    /// Это основной путь к текущему DXGI swapchain.
+    pub const CURRENT_SWAPCHAIN: usize = 0x27A8;
+
+    /// `+0x27B0` → дополнительный указатель на активный swapchain wrapper.
+    pub const ACTIVE_SWAPCHAIN: usize = 0x27B0;
+
+    /// `+0x510C` → флаги адаптера / init flags.
+    ///
+    /// Влияют на выбор режима swapchain.
+    pub const ADAPTER_FLAGS: usize = 0x510C;
+
+    /// `+0x5110` → `ID3DUserDefinedAnnotation*` или NULL.
+    pub const DEBUG_ANNOTATION: usize = 0x5110;
+}
+
+pub mod swapchain_manager {
+    /// `+0x00` → root/sentinel узел RB-дерева.
+    ///
+    /// Ключ дерева: `HWND`
+    /// Значение: `M2DE_SwapChainWrapper*`
+    pub const TREE_ROOT: usize = 0x00;
+
+    /// `+0x08` → количество элементов в дереве.
+    pub const TREE_SIZE: usize = 0x08;
+
+    /// `+0x10` → `IDXGIFactory4*`
+    pub const FACTORY: usize = 0x10;
+
+    /// `+0x18` → `ID3D11Device*`
+    pub const DEVICE: usize = 0x18;
+
+    /// `+0x20` → `ID3D11DeviceContext*`
+    pub const CONTEXT: usize = 0x20;
+
+    /// `+0x28` → поддерживается ли `DXGI_FEATURE_PRESENT_ALLOW_TEARING`.
+    pub const TEARING_SUPPORTED: usize = 0x28;
+
+    /// `+0x29` → debug mode флаг.
+    pub const DEBUG_MODE: usize = 0x29;
+}
+
+pub mod swapchain_wrapper {
+    /// `+0x00` → ширина swapchain.
+    pub const WIDTH: usize = 0x00;
+
+    /// `+0x04` → высота swapchain.
+    pub const HEIGHT: usize = 0x04;
+
+    /// `+0x08` → режим / флаг swapchain.
+    pub const SWAPCHAIN_MODE: usize = 0x08;
+
+    /// `+0x10` → HWND окна.
+    pub const HWND: usize = 0x10;
+
+    /// `+0x18` → `IDXGISwapChain1*`
+    ///
+    /// Это raw DXGI swapchain, который нужен для hook'а `Present`.
+    pub const SWAPCHAIN: usize = 0x18;
+
+    /// `+0x20` → `ID3D11Texture2D*` back buffer.
+    pub const BACK_BUFFER: usize = 0x20;
+
+    /// `+0x28` → `ID3D11Texture2D*` depth texture.
+    pub const DEPTH_TEXTURE: usize = 0x28;
+
+    /// `+0x30` → `ID3D11DepthStencilView*`
+    pub const DSV: usize = 0x30;
+
+    /// `+0x38` → `ID3D11RenderTargetView*`
+    pub const RTV: usize = 0x38;
+
+    /// `+0x40` → `ID3D11ShaderResourceView*`
+    pub const SRV: usize = 0x40;
+}

--- a/sdk/src/addresses/functions.rs
+++ b/sdk/src/addresses/functions.rs
@@ -811,3 +811,106 @@ pub mod entity_messages {
     /// IDA: `0x140DA4C80`
     pub const HUMAN_SEND_ENTER_VEHICLE_LIKE: usize = 0xDA_4C80;
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Render Device
+// ═══════════════════════════════════════════════════════════════════════════
+
+pub mod render {
+    /// Полный конструктор `M2DE_C_RenderDeviceD3D11`.
+    ///
+    /// IDA: `0x1409C36A0`
+    pub const RENDER_DEVICE_D3D11_CTOR: usize = 0x9C_36A0;
+
+    /// Промежуточный конструктор render-device цепочки.
+    ///
+    /// IDA: `0x1409C3E20`
+    pub const RENDER_DEVICE_MID_CTOR: usize = 0x9C_3E20;
+
+    /// Базовый конструктор render-device.
+    ///
+    /// Именно здесь игра сохраняет глобальный singleton
+    /// в `qword_141CD5D18`.
+    ///
+    /// IDA: `0x1408CA120`
+    pub const RENDER_DEVICE_BASE_CTOR: usize = 0x8C_A120;
+
+    /// Teardown / cleanup path для `M2DE_C_RenderDeviceD3D11`.
+    ///
+    /// IDA: `0x1409C5040`
+    pub const RENDER_DEVICE_D3D11_TEARDOWN: usize = 0x9C_5040;
+
+    /// Scalar deleting destructor.
+    ///
+    /// IDA: `0x1409C60D0`
+    pub const RENDER_DEVICE_D3D11_SCALAR_DTOR: usize = 0x9C_60D0;
+
+    /// Возвращает строку `"D3D11 Rendering Device"`.
+    ///
+    /// IDA: `0x1409CBEA0`
+    pub const RENDER_DEVICE_D3D11_GET_NAME: usize = 0x9C_BEA0;
+
+    /// Основная DX11 инициализация.
+    ///
+    /// Создаёт:
+    /// - `ID3D11Device`
+    /// - `ID3D11DeviceContext`
+    /// - DXGI factory
+    /// - swapchain wrapper
+    /// - базовые render states
+    ///
+    /// IDA: `0x1409CC4B0`
+    pub const RENDER_DEVICE_D3D11_INIT: usize = 0x9C_C4B0;
+
+    /// Создание swapchain wrapper и raw `IDXGISwapChain1`.
+    ///
+    /// Внутри вызывает `IDXGIFactory4::CreateSwapChainForHwnd`.
+    ///
+    /// IDA: `0x1409C9EE0`
+    pub const CREATE_SWAPCHAIN: usize = 0x9C_9EE0;
+
+    /// Создание RTV / SRV / depth texture / DSV для swapchain wrapper.
+    ///
+    /// IDA: `0x1409CD1A0`
+    pub const SWAPCHAIN_WRAPPER_CREATE_VIEWS: usize = 0x9C_D1A0;
+
+    /// Recreate/resize path для swapchain.
+    ///
+    /// Если HWND тот же — идёт resize path.
+    /// Если HWND другой — создаётся новый wrapper/swapchain.
+    ///
+    /// IDA: `0x1409CE650`
+    pub const RENDER_DEVICE_D3D11_RECREATE_SWAPCHAIN: usize = 0x9C_E650;
+
+    /// Установка default render states.
+    ///
+    /// IDA: `0x14098E620`
+    pub const RENDER_DEVICE_D3D11_SET_DEFAULT_STATES: usize = 0x98_E620;
+
+    /// Создание dynamic VB/IB буферов.
+    ///
+    /// IDA: `0x140A12FC0`
+    pub const RENDER_DEVICE_D3D11_CREATE_DYNAMIC_BUFFERS: usize = 0xA1_2FC0;
+
+    /// Проверка debug device режима.
+    ///
+    /// В retail-сборке возвращает 0.
+    ///
+    /// IDA: `0x140A13AE0`
+    pub const IS_DEBUG_DEVICE: usize = 0xA1_3AE0;
+
+    /// Перечисление адаптеров DXGI.
+    ///
+    /// IDA: `0x1409CD2B0`
+    pub const RENDER_DEVICE_D3D11_ENUM_ADAPTERS: usize = 0x9C_D2B0;
+
+    /// Thunk на `D3D11CreateDevice`.
+    ///
+    /// IDA: `0x14153F09D`
+    pub const D3D11_CREATE_DEVICE_THUNK: usize = 0x153_F09D;
+
+    /// Thunk на `CreateDXGIFactory1`.
+    ///
+    /// IDA: `0x14153F0B5`
+    pub const CREATE_DXGI_FACTORY1_THUNK: usize = 0x153_F0B5;
+}

--- a/sdk/src/addresses/globals.rs
+++ b/sdk/src/addresses/globals.rs
@@ -98,3 +98,40 @@ pub const STATS_TRACKER_2: usize = 0x314_0BD0;
 /// `array[0] -> Main Game Script Machine`
 /// `script_machine + 0x70 -> lua_State*`
 pub const SCRIPT_MACHINE_MANAGER: usize = 0x1CB_1238;
+
+/// `M2DE_C_RenderDeviceD3D11*` — глобальный singleton рендер-устройства.
+///
+/// Это главный объект DX11 backend'а игры.
+/// Через него можно получить:
+/// - `IDXGIFactory*`
+/// - `ID3D11Device*`
+/// - `ID3D11DeviceContext*`
+/// - текущий `M2DE_SwapChainWrapper*`
+///
+/// Цепочка до raw swapchain:
+/// `RENDER_DEVICE -> current_swapchain -> swapchain`
+///
+/// IDA: `qword_141CD5D18`
+pub const RENDER_DEVICE: usize = 0x1CD_5D18;
+
+/// Флаг особого режима окружения / remote session.
+///
+/// Используется рендером при выборе ограничения на размер текстур.
+///
+/// IDA: `byte_141CD5CF2`
+pub const RENDER_IS_REMOTE_SESSION: usize = 0x1CD_5CF2;
+
+/// Базовый лимит размеров текстур.
+///
+/// IDA: `dword_141C34DD0`
+pub const RENDER_DEFAULT_MAX_TEXTURE_SIZE: usize = 0x1C3_4DD0;
+
+/// Лимит размеров текстур для обычного локального запуска.
+///
+/// IDA: `dword_141C3589C`
+pub const RENDER_MAX_TEXTURE_SIZE_LOCAL: usize = 0x1C3_589C;
+
+/// Лимит размеров текстур для special/remote режима.
+///
+/// IDA: `dword_141C358A0`
+pub const RENDER_MAX_TEXTURE_SIZE_REMOTE: usize = 0x1C3_58A0;

--- a/sdk/src/addresses/mod.rs
+++ b/sdk/src/addresses/mod.rs
@@ -7,6 +7,7 @@
 //! runtime_address = module_base + RVA
 //! ```
 
+pub mod data;
 pub mod globals;
 pub mod functions;
 pub mod vtables;

--- a/sdk/src/addresses/strings.rs
+++ b/sdk/src/addresses/strings.rs
@@ -44,3 +44,10 @@ pub mod garage_strings {
     /// "SpikeStrip"
     pub const SPIKE_STRIP: usize = 0x190_D470;
 }
+
+pub mod render_strings {
+    /// `"D3D11 Rendering Device"`
+    ///
+    /// IDA: `0x1418A3C88`
+    pub const D3D11_RENDERING_DEVICE: usize = 0x18A_3C88;
+}

--- a/sdk/src/addresses/vtables.rs
+++ b/sdk/src/addresses/vtables.rs
@@ -57,3 +57,35 @@ pub mod misc {
     /// IDA: `0x1418E9198`
     pub const CRASH_OBJ_MGR: usize = 0x18E_9198;
 }
+
+pub mod render_device {
+    /// Самая базовая abstract vtable render-device.
+    ///
+    /// IDA: `0x14189AF80`
+    pub const ABSTRACT: usize = 0x189_AF80;
+
+    /// Промежуточная vtable в ctor-цепочке.
+    ///
+    /// IDA: `0x1418A2F80`
+    pub const MID: usize = 0x18A_2F80;
+
+    /// Базовая vtable `C_RenderDevice`.
+    ///
+    /// IDA: `0x1418A3310`
+    pub const BASE: usize = 0x18A_3310;
+
+    /// Финальная vtable `M2DE_C_RenderDeviceD3D11`.
+    ///
+    /// IDA: `0x1418A38C0`
+    pub const D3D11: usize = 0x18A_38C0;
+
+    /// Временная vtable state-tracker объекта.
+    ///
+    /// IDA: `0x1418A2870`
+    pub const STATE_TRACKER_INITIAL: usize = 0x18A_2870;
+
+    /// Финальная vtable state-tracker объекта.
+    ///
+    /// IDA: `0x1418A2960`
+    pub const STATE_TRACKER_FINAL: usize = 0x18A_2960;
+}

--- a/sdk/src/game/mod.rs
+++ b/sdk/src/game/mod.rs
@@ -3,6 +3,7 @@
 pub mod callbacks;
 pub mod player;
 pub mod lua;
+pub mod render;
 
 pub use player::Player;
 

--- a/sdk/src/game/render.rs
+++ b/sdk/src/game/render.rs
@@ -1,0 +1,258 @@
+//! High-level API для доступа к DX11 render path игры.
+//!
+//! Этот модуль нужен injected-клиенту, чтобы без pattern-scan и без догадок:
+//! - получить `ID3D11Device*`
+//! - получить `ID3D11DeviceContext*`
+//! - получить текущий `IDXGISwapChain1*`
+//! - получить `ID3D11RenderTargetView*` текущего backbuffer
+//! - получить HWND и размеры рендера
+//!
+//! Это удобно и для overlay/debug UI, и для диагностики render lifecycle.
+
+use common::logger;
+
+use crate::{
+    addresses,
+    memory,
+    structures::{
+        CRenderDeviceD3D11,
+        SwapChainManager,
+        SwapChainWrapper,
+    },
+};
+
+use super::base;
+
+/// Снимок текущего runtime-состояния рендера.
+///
+/// Это просто удобная структура для логов и overlay-диагностики.
+#[derive(Debug, Clone, Copy)]
+pub struct RenderRuntimeInfo {
+    pub render_device_ptr: usize,
+    pub dxgi_factory_ptr: usize,
+    pub d3d_device_ptr: usize,
+    pub d3d_context_ptr: usize,
+    pub swapchain_manager_ptr: usize,
+    pub swapchain_wrapper_ptr: usize,
+    pub swapchain_ptr: usize,
+    pub hwnd: usize,
+    pub width: u32,
+    pub height: u32,
+    pub feature_level: u32,
+    pub adapter_flags: u32,
+    pub tearing_supported: bool,
+    pub dx_initialized: bool,
+    pub rtv_ptr: usize,
+    pub dsv_ptr: usize,
+    pub back_buffer_ptr: usize,
+}
+
+/// Возвращает указатель на глобальный `M2DE_C_RenderDeviceD3D11`.
+pub fn get_render_device_ptr() -> Option<usize> {
+    unsafe { memory::read_ptr(base() + addresses::globals::RENDER_DEVICE) }
+}
+
+/// Читает snapshot структуры `C_RenderDeviceD3D11`.
+pub fn get_render_device() -> Option<CRenderDeviceD3D11> {
+    let ptr = get_render_device_ptr()?;
+    unsafe { memory::read_value::<CRenderDeviceD3D11>(ptr) }
+}
+
+/// Возвращает указатель на `SwapChainManager`.
+pub fn get_swapchain_manager_ptr() -> Option<usize> {
+    let rd = get_render_device()?;
+    let ptr = rd.swapchain_manager as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Читает `SwapChainManager`.
+pub fn get_swapchain_manager() -> Option<SwapChainManager> {
+    let ptr = get_swapchain_manager_ptr()?;
+    unsafe { memory::read_value::<SwapChainManager>(ptr) }
+}
+
+/// Возвращает указатель на текущий `SwapChainWrapper`.
+pub fn get_swapchain_wrapper_ptr() -> Option<usize> {
+    let rd = get_render_device()?;
+    let ptr = rd.current_swapchain as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Читает текущий `SwapChainWrapper`.
+pub fn get_swapchain_wrapper() -> Option<SwapChainWrapper> {
+    let ptr = get_swapchain_wrapper_ptr()?;
+    unsafe { memory::read_value::<SwapChainWrapper>(ptr) }
+}
+
+/// Возвращает raw `IDXGISwapChain1*`.
+pub fn get_swapchain_ptr() -> Option<usize> {
+    let sc = get_swapchain_wrapper()?;
+    let ptr = sc.swapchain as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Возвращает `ID3D11Device*`.
+pub fn get_d3d_device_ptr() -> Option<usize> {
+    let rd = get_render_device()?;
+    let ptr = rd.d3d_device as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Возвращает `ID3D11DeviceContext*`.
+pub fn get_d3d_context_ptr() -> Option<usize> {
+    let rd = get_render_device()?;
+    let ptr = rd.d3d_context as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Возвращает `IDXGIFactory1*`.
+pub fn get_dxgi_factory_ptr() -> Option<usize> {
+    let rd = get_render_device()?;
+    let ptr = rd.dxgi_factory as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Возвращает `ID3D11RenderTargetView*` текущего backbuffer.
+pub fn get_backbuffer_rtv_ptr() -> Option<usize> {
+    let sc = get_swapchain_wrapper()?;
+    let ptr = sc.rtv as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Возвращает `ID3D11DepthStencilView*`.
+pub fn get_backbuffer_dsv_ptr() -> Option<usize> {
+    let sc = get_swapchain_wrapper()?;
+    let ptr = sc.dsv as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Возвращает `ID3D11Texture2D*` backbuffer.
+pub fn get_backbuffer_texture_ptr() -> Option<usize> {
+    let sc = get_swapchain_wrapper()?;
+    let ptr = sc.back_buffer as usize;
+    memory::is_valid_ptr(ptr).then_some(ptr)
+}
+
+/// Возвращает HWND окна игры.
+pub fn get_hwnd() -> Option<usize> {
+    let sc = get_swapchain_wrapper()?;
+    (sc.hwnd != 0).then_some(sc.hwnd)
+}
+
+/// Возвращает размеры из текущего swapchain wrapper.
+pub fn get_swapchain_size() -> Option<(u32, u32)> {
+    let sc = get_swapchain_wrapper()?;
+    Some((sc.width, sc.height))
+}
+
+/// Возвращает размеры рендера из render init config.
+pub fn get_render_size() -> Option<(u32, u32)> {
+    let rd = get_render_device()?;
+    Some((rd.render_init.width, rd.render_init.height))
+}
+
+/// Возвращает текущий `D3D_FEATURE_LEVEL`.
+pub fn get_feature_level() -> Option<u32> {
+    let rd = get_render_device()?;
+    Some(rd.feature_level)
+}
+
+/// Возвращает tearing support флаг.
+pub fn is_tearing_supported() -> Option<bool> {
+    let mgr = get_swapchain_manager()?;
+    Some(mgr.tearing_supported != 0)
+}
+
+/// Возвращает true, если render path уже готов для overlay.
+pub fn is_overlay_ready() -> bool {
+    get_render_device_ptr().is_some()
+        && get_d3d_device_ptr().is_some()
+        && get_d3d_context_ptr().is_some()
+        && get_swapchain_ptr().is_some()
+        && get_backbuffer_rtv_ptr().is_some()
+}
+
+/// Переводит `D3D_FEATURE_LEVEL` в человекочитаемую строку.
+pub fn feature_level_name(level: u32) -> &'static str {
+    match level {
+        0x9100 => "D3D_FEATURE_LEVEL_9_1",
+        0x9200 => "D3D_FEATURE_LEVEL_9_2",
+        0x9300 => "D3D_FEATURE_LEVEL_9_3",
+        0xA000 => "D3D_FEATURE_LEVEL_10_0",
+        0xA100 => "D3D_FEATURE_LEVEL_10_1",
+        0xB000 => "D3D_FEATURE_LEVEL_11_0",
+        0xB100 => "D3D_FEATURE_LEVEL_11_1",
+        _ => "UNKNOWN",
+    }
+}
+
+/// Собирает удобный runtime snapshot.
+pub fn get_runtime_info() -> Option<RenderRuntimeInfo> {
+    let render_device_ptr = get_render_device_ptr()?;
+    let rd = get_render_device()?;
+    let mgr = get_swapchain_manager()?;
+    let sc = get_swapchain_wrapper()?;
+
+    Some(RenderRuntimeInfo {
+        render_device_ptr,
+        dxgi_factory_ptr: rd.dxgi_factory as usize,
+        d3d_device_ptr: rd.d3d_device as usize,
+        d3d_context_ptr: rd.d3d_context as usize,
+        swapchain_manager_ptr: rd.swapchain_manager as usize,
+        swapchain_wrapper_ptr: rd.current_swapchain as usize,
+        swapchain_ptr: sc.swapchain as usize,
+        hwnd: sc.hwnd,
+        width: sc.width,
+        height: sc.height,
+        feature_level: rd.feature_level,
+        adapter_flags: rd.adapter_flags,
+        tearing_supported: mgr.tearing_supported != 0,
+        dx_initialized: rd.dx_initialized != 0,
+        rtv_ptr: sc.rtv as usize,
+        dsv_ptr: sc.dsv as usize,
+        back_buffer_ptr: sc.back_buffer as usize,
+    })
+}
+
+/// Пишет в лог краткий snapshot render state.
+///
+/// Удобно вызывать после инъекта и после загрузки мира.
+pub fn dump_runtime_info() {
+    let Some(info) = get_runtime_info() else {
+        logger::warn("[render] render path пока не готов");
+        return;
+    };
+
+    logger::info(&format!(
+        "[render] render_device=0x{:X} factory=0x{:X} device=0x{:X} context=0x{:X}",
+        info.render_device_ptr,
+        info.dxgi_factory_ptr,
+        info.d3d_device_ptr,
+        info.d3d_context_ptr,
+    ));
+
+    logger::info(&format!(
+        "[render] wrapper=0x{:X} swapchain=0x{:X} hwnd=0x{:X}",
+        info.swapchain_wrapper_ptr,
+        info.swapchain_ptr,
+        info.hwnd,
+    ));
+
+    logger::info(&format!(
+        "[render] size={}x{} rtv=0x{:X} dsv=0x{:X} backbuffer=0x{:X}",
+        info.width,
+        info.height,
+        info.rtv_ptr,
+        info.dsv_ptr,
+        info.back_buffer_ptr,
+    ));
+
+    logger::info(&format!(
+        "[render] feature_level=0x{:X} ({}) flags=0x{:X} tearing={} dx_initialized={}",
+        info.feature_level,
+        feature_level_name(info.feature_level),
+        info.adapter_flags,
+        info.tearing_supported,
+        info.dx_initialized,
+    ));
+}

--- a/sdk/src/structures/mod.rs
+++ b/sdk/src/structures/mod.rs
@@ -7,6 +7,7 @@ mod garage;
 mod tables;
 mod callbacks;
 mod messages;
+mod render;
 
 pub use core::*;
 pub use player::*;
@@ -17,3 +18,4 @@ pub use garage::*;
 pub use tables::*;
 pub use callbacks::*;
 pub use messages::*;
+pub use render::*;


### PR DESCRIPTION
Added reverse-engineered DX11 render path data for Mafia II: Definitive Edition:
- global render device singleton RVA
- render device field offsets
- swapchain manager and swapchain wrapper field offsets
- DX11/DXGI init and swapchain function RVAs
- render-related vtable RVAs
- render/DXGI string and IID data RVAs
- reconstructed `M2DE_C_RenderDeviceD3D11`
- reconstructed `M2DE_SwapChainManager`
- reconstructed `M2DE_SwapChainWrapper`
- high-level render helpers for device/context/swapchain/RTV access

This commit captures the current reverse-engineered SDK knowledge for:
- D3D11 device/context initialization
- DXGI factory ownership
- swapchain creation and recreate path
- backbuffer RTV/DSV/SRV access
- injected overlay integration points