### PR TITLE
feat(sdk): add C_Human health, damage, inventory and physics reverse …

### DIFF
--- a/sdk/src/addresses/constants.rs
+++ b/sdk/src/addresses/constants.rs
@@ -203,18 +203,22 @@ pub mod human_messages {
     pub const PLAYER_WEAPON_HIDE: u32    = 852_005;  // 0xD0025
     pub const SHOT: u32                  = 852_071;  // 0xD0057
 
-    pub const WEAPON_HOLSTER: u32        = 851_999;  // 0xD001F  conf 78%
-    pub const WEAPON_DRAW: u32           = 852_000;  // 0xD0020  conf 80%
-    pub const STANCE_CHANGE: u32         = 852_001;  // 0xD0021  conf 72%
-    pub const STANCE_CLEANUP: u32        = 852_002;  // 0xD0022  conf 68%
-    pub const STANCE_SECONDARY: u32      = 852_003;  // 0xD0023  conf 68%
-    pub const HEAD_DAMAGE: u32           = 852_033;  // 0xD0041  conf 85%
-    pub const BODY_DAMAGE: u32           = 852_034;  // 0xD0042  conf 85%
-    pub const KILL_DAMAGE: u32           = 852_035;  // 0xD0043  conf 80%
+    pub const WEAPON_HOLSTER: u32        = 851_999;  // 0xD001F
+    pub const WEAPON_DRAW: u32           = 852_000;  // 0xD0020
+    pub const STANCE_CHANGE: u32         = 852_001;  // 0xD0021
+    pub const STANCE_CLEANUP: u32        = 852_002;  // 0xD0022
+    pub const STANCE_SECONDARY: u32      = 852_003;  // 0xD0023
+    pub const HEAD_DAMAGE: u32           = 852_033;  // 0xD0041
+    pub const BODY_DAMAGE: u32           = 852_034;  // 0xD0042
+    pub const KILL_DAMAGE: u32           = 852_035;  // 0xD0043
 
-    pub const HUMAN_MODE_CHANGE: u32     = 851_972;  // 0xD0004  conf 70%
-    pub const HUMAN_TICK: u32            = 851_985;  // 0xD0011  conf 78%
-    pub const HUMAN_SETTLED: u32         = 851_994;  // 0xD001A  conf 72%
+    pub const HUMAN_MODE_CHANGE: u32     = 851_972;  // 0xD0004
+    pub const HUMAN_TICK: u32            = 851_985;  // 0xD0011
+    pub const HUMAN_SETTLED: u32         = 851_994;  // 0xD001A
+
+    /// Убрать оружие (holster). Для player — отправляется как entity message.
+    /// Для NPC — пишется напрямую в behavior+0x248.
+    pub const HOLSTER_WEAPON: u32        = 852_053;  // 0xD0055
 }
 
 /// Диапазоны event_type для быстрой классификации message_id.

--- a/sdk/src/addresses/fields.rs
+++ b/sdk/src/addresses/fields.rs
@@ -20,25 +20,104 @@ pub mod player {
     /// IDA: `0x140DA7630` fallback path reads `[rcx+0x78]`
     pub const FRAME_NODE: usize = 0x78;
 
-    /// `+0x258` → Physics body handler (optional, may be NULL)
-    ///
-    /// When present, position is read via vtable[0xA8] instead of frame node.
-    pub const PHYSICS_HANDLER: usize = 0x258;
+    /// `+0x024` → uint8 тип сущности.
+    /// 0x10 = игрок, 0x0E = NPC-человек, 0x12 = физическое тело.
+    pub const ENTITY_TYPE: usize = 0x24;
+
+    /// `+0x080` → C_Entity* владелец.
+    /// Пешком = NULL, в машине = указатель на vehicle entity.
+    pub const OWNER: usize = 0x80;
+
+    /// `+0x0C0` → AI/Navigation компонент.
+    /// vtbl 0x1418E3290. Хранит текущую AI-позицию.
+    pub const AI_NAV_COMPONENT: usize = 0xC0;
+
+    /// `+0x0D0` → TransformSync компонент.
+    /// vtbl 0x1418E33A8. Синхронизирует позицию из актора ~258 раз/сек.
+    /// comp+0x18 = Vec3 позиция, comp+0x24 = параметр (100.0).
+    pub const TRANSFORM_SYNC: usize = 0xD0;
+
+    /// `+0x0F8` → Behavior компонент.
+    /// vtbl 0x1418E37A8. Сюда пересылаются сообщения из HandleMessage.
+    pub const BEHAVIOR_COMPONENT: usize = 0xF8;
+
+    /// `+0x108` → Компонент состояния оружия.
+    /// *(component + 0x2B0) → указатель на ID выбранного оружия (uint32).
+    pub const WEAPON_STATE_COMPONENT: usize = 0x108;
+
+    /// `+0x148` → float текущее здоровье.
+    /// 720.0 = полное на нормальной сложности.
+    pub const CURRENT_HEALTH: usize = 0x148;
+
+    /// `+0x14C` → float.
+    /// Для NPC: максимальное здоровье.
+    /// Для игрока: множитель урона определённых типов (12/15/22).
+    /// Максимум здоровья игрока берётся из g_M2DE_PlayerData+0x00.
+    pub const NPC_HEALTHMAX: usize = 0x14C;
+
+    /// `+0x150` → float множитель урона от NPC.
+    /// Lua возвращает это * 100.0 как проценты. Default 1.0 (= 100%).
+    pub const NONPLAYER_DAMAGE_MULT: usize = 0x150;
+
+    /// `+0x154` → float пороговая дистанция для снижения урона.
+    /// Default 5.0.
+    pub const NONPLAYER_DAMAGE_DIST: usize = 0x154;
+
+    /// `+0x160` → uint8 флаг неуязвимости.
+    /// 0 = обычный режим, 1 = неуязвим (урон пропускается полностью).
+    pub const INVULNERABILITY: usize = 0x160;
+
+    /// `+0x161` → uint8 флаг смерти.
+    /// IsDeath() = vtable[47] = return *(this + 353).
+    pub const IS_DEAD: usize = 0x161;
+
+    /// `+0x162` → uint8 флаг полубога.
+    /// Если установлен — здоровье не опускается ниже 1.0.
+    pub const DEMIGOD: usize = 0x162;
+
+    /// `+0x180` → float* массив множителей урона по частям тела.
+    /// [4]=голова, [5]=торс, [6]=руки, [7]=ноги.
+    pub const BODY_DAMAGE_MULTIPLIERS: usize = 0x180;
+
+    /// `+0x190` → C_Human* ссылка на самого себя (== this).
+    /// Используется для валидации указателя.
+    pub const SELF_REF: usize = 0x190;
+
+    /// `+0x258` → Physics provider (выделен в куче отдельно).
+    /// vtbl 0x141993998. Используется GetPos/SetPos для physics-пути.
+    pub const PHYSICS_PROVIDER: usize = 0x258;
+
+    /// `+0x338` → Vec3 позиция смерти (12 байт).
+    /// Записывается когда здоровье достигает 0.
+    pub const DEATH_POSITION: usize = 0x338;
+
+    /// `+0x344` → int32 тип смерти (1=обычная, 128=взрыв).
+    pub const DEATH_TYPE: usize = 0x344;
 }
 
 pub mod inventory {
+    /// `+0x08` → Корень RB-дерева поиска оружия по ID.
+    /// std::map<int32, WeaponData*>.
+    /// node+0x20 = weapon_id (ключ), node+0x28 = weapon data ptr.
+    pub const WEAPON_TREE: usize = 0x08;
+
+    /// `+0x24` → uint8 тип инвентаря (0=player).
     pub const TYPE: usize = 0x24;
+
+    /// `+0x50` → начало массива указателей на слоты.
+    /// *(slots_begin + N*8) = Slot* для слота N.
     pub const SLOTS_START: usize = 0x50;
+
+    /// `+0x58` → конец массива слотов.
     pub const SLOTS_END: usize = 0x58;
-    pub const WEAPONS: usize = 0xE8;
-    
-    /// `+0x170` → back-pointer на entity-владельца (C_Human* для игрока)
-    ///
-    /// Проверка `*(parent + 0x24) == 16` в игре определяет
-    /// показывать ли HUD popup. Для player это значение = 0,
-    /// поэтому HUD вызывается через g_HUDManager напрямую.
+
+    /// `+0x168` → bool бесконечные патроны.
+    pub const UNLIMITED_AMMO: usize = 0x168;
+
+    /// `+0x170` → C_Human* обратная ссылка на владельца.
     pub const OWNER_ENTITY_REF: usize = 0x170;
 }
+
 
 pub mod money_item {
     /// `+0x18` → MoneyCore* (M2DE_MoneyItem_GetCore возвращает [a1+0x18])
@@ -54,29 +133,66 @@ pub mod money_core {
     pub const CONTAINER_PTR: usize = 0x10;
 }
 
-/// Структура слота инвентаря (например MoneySlot).
-///
-/// ```text
-/// +0x00: vtable
-/// +0x08: back-pointer на Inventory
-/// +0x10: i32 (-1?)
-/// +0x14: i32 (0x80?)
-/// +0x18: vec_begin — начало внутреннего std::vector<ptr>
-/// +0x20: vec_end   — конец вектора
-/// +0x28: vec_capacity
-/// ```
-///
-/// IDA: `M2DE_Inventory_GetMoneyPtrFromArray`:
-/// ```c
-/// rdx = *(slot + 0x18);  // vec_begin
-/// rax = *(slot + 0x20);  // vec_end
-/// ```
-pub mod slot {
-    /// `+0x18` → начало внутреннего вектора (std::vector begin)
-    pub const VEC_BEGIN: usize = 0x18;
+/// Индексы слотов инвентаря.
+pub mod slots {
+    /// Слот 0 — текущее оружие в руках
+    pub const CURRENT_WEAPON: usize = 0;
+    /// Слот 1 — неизвестно
+    pub const UNKNOWN_1: usize = 1;
+    /// Слот 2 — оружейный слот 1 (пистолеты, дробовики)
+    pub const WEAPON_1: usize = 2;
+    /// Слот 3 — оружейный слот 2 (винтовки, автоматы)
+    pub const WEAPON_2: usize = 3;
+    /// Слот 4 — запас патронов
+    pub const AMMO: usize = 4;
+    /// Слот 5 — деньги
+    pub const MONEY: usize = 5;
+}
 
-    /// `+0x20` → конец внутреннего вектора (std::vector end)
+/// Структура одного слота инвентаря.
+pub mod slot {
+    /// `+0x18` → начало std::vector<ptr> элементов
+    pub const VEC_BEGIN: usize = 0x18;
+    /// `+0x20` → конец std::vector
     pub const VEC_END: usize = 0x20;
+    /// `+0x50` → указатель на weapon table entry
+    pub const TABLE_ENTRY: usize = 0x50;
+}
+
+/// Запись из /tables/weapons.tbl.
+pub mod weapon_table_entry {
+    /// `+0x24` → int32 flags. Бит 1 (& 2): слот назначения
+    pub const FLAGS: usize = 0x24;
+    /// `+0x58` → int32 максимальная ёмкость обоймы
+    pub const MAX_AMMO: usize = 0x58;
+}
+
+/// Данные оружия (из RB-дерева или weapon_state компонента).
+pub mod weapon_data {
+    /// `+0x00` → int32 ID оружия
+    pub const WEAPON_ID: usize = 0x00;
+    /// `+0x10` → ptr → container → +0x10 → int32 текущие патроны
+    pub const AMMO_CONTAINER: usize = 0x10;
+    /// `+0x24` → uint32 флаги типа оружия
+    ///   бит 5 (0x20) = огнестрельное
+    pub const WEAPON_FLAGS: usize = 0x24;
+}
+
+/// Битовые флаги типа оружия (weapon_data+0x24).
+pub mod weapon_type_flags {
+    /// Холодное оружие (нож, бита, кулаки)
+    pub const COLD_WEAPON: u32 = 0x04;
+    /// Огнестрельное оружие (пистолет, автомат, дробовик, винтовка)
+    pub const FIRE_WEAPON: u32 = 0x20;
+    /// Метательное оружие (граната, молотов)
+    pub const THROWING_WEAPON: u32 = 0x200000;
+}
+
+/// Weapon State Component (player+0x108).
+pub mod weapon_state {
+    /// `+0x2B0` → ptr на WeaponData текущего оружия в руках
+    /// NULL = руки пусты.
+    pub const CURRENT_WEAPON_DATA: usize = 0x2B0;
 }
 
 /// Объект "wallet" — первый элемент вектора слота.
@@ -129,17 +245,25 @@ pub mod hud_money_display {
 }
 
 pub mod entity_frame {
-    /// `+0x64` → Position X (f32)
-    ///
-    /// Part of 4x4 transform matrix starting at +0x58.
-    /// Position is in the last column of each row (stride 0x10).
-    ///
-    /// IDA: `0x140DA7630` reads `[frame+0x64]`, `[frame+0x74]`, `[frame+0x84]`
+    // Позиция
     pub const POS_X: usize = 0x64;
-    /// `+0x74` → Position Y (f32)
     pub const POS_Y: usize = 0x74;
-    /// `+0x84` → Position Z (f32)
     pub const POS_Z: usize = 0x84;
+
+    // Right вектор (Col0) — направление вправо от персонажа
+    pub const RIGHT_X: usize = 0x58;
+    pub const RIGHT_Y: usize = 0x68;
+    pub const RIGHT_Z: usize = 0x78;
+
+    // Forward вектор (Col1) — куда смотрит персонаж (в XY плоскости)
+    pub const FORWARD_X: usize = 0x5C;
+    pub const FORWARD_Y: usize = 0x6C;
+    pub const FORWARD_Z: usize = 0x7C;
+
+    // Up вектор (Col2) — мировой "вверх" (обычно 0,0,1)
+    pub const UP_X: usize = 0x60;
+    pub const UP_Y: usize = 0x70;
+    pub const UP_Z: usize = 0x80;
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/sdk/src/addresses/functions.rs
+++ b/sdk/src/addresses/functions.rs
@@ -946,3 +946,79 @@ pub mod camera {
     /// IDA: `0x140E6BC00`
     pub const VIEW_COPY_DEFAULTS_TO_STATES: usize = 0xE6_BC00;
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Human / Health
+// ═══════════════════════════════════════════════════════════════════════════
+
+pub mod human {
+    /// `bool(C_Human*)` — is entity dead.
+    /// vtable[47]. return *(uint8*)(this + 0x161).
+    /// IDA: `0x1400C4690`
+    pub const IS_DEATH: usize = 0x0C_4690;
+
+    /// `char(C_Human*, EntityMessage*)` — process incoming damage.
+    /// vtable[82]. Saves health, calls damage processor, handles death.
+    /// IDA: `0x1400C00B0`
+    pub const PROCESS_DAMAGE: usize = 0x0C_00B0;
+
+    /// `char(C_Human*, EntityMessage*)` — core damage calculation.
+    /// Guards: IsDeath() || invulnerability(+0x160).
+    /// Subtracts from health(+0x148). Checks demigod(+0x162).
+    /// IDA: `0x140D93B80`
+    pub const APPLY_DAMAGE: usize = 0xD9_3B80;
+
+    /// `void(C_Human*, EntityMessage*)` — death handler.
+    /// Called when health <= 0 and !demigod.
+    /// IDA: look for M2DE_HumanEntity_ProcessDeath xref in ApplyDamage
+    pub const PROCESS_DEATH: usize = 0; // TODO: exact address
+
+    /// `float(C_Human*)` — get current health.
+    /// return *(float*)(*(component) + 0x148).
+    /// IDA: `0x140DA3C30`
+    pub const GET_HEALTH: usize = 0xDA_3C30;
+
+    /// `float(ComponentRef*)` — get healthmax.
+    /// Player: reads g_PlayerData+0x00. NPC: reads entity+0x14C.
+    /// IDA: `0x140DA3C50`
+    pub const GET_HEALTH_MAX: usize = 0xDA_3C50;
+
+    /// `uint8(ComponentRef*)` — get invulnerability flag.
+    /// return *(uint8*)(*(a1) + 0x160).
+    /// IDA: `0x140DA5460`
+    pub const GET_INVULNERABILITY: usize = 0xDA_5460;
+
+    /// `void(ComponentRef*, uint8)` — set invulnerability flag.
+    /// *(*(a1) + 0x160) = value.
+    /// IDA: `0x140DD0300`
+    pub const SET_INVULNERABILITY: usize = 0xDD_0300;
+
+    /// `void*(void)` — get global player data singleton.
+    /// Returns &g_M2DE_PlayerData.
+    /// IDA: `0x1400C33C0`
+    pub const GET_PLAYER_INSTANCE: usize = 0x0C_33C0;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Physics Provider
+// ═══════════════════════════════════════════════════════════════════════════
+
+pub mod physics {
+    /// Получить текущий physics state через property accessor.
+    /// Внутри: *(player+0x258)->vtable[53]
+    /// IDA: `0x140DCCEC0`
+    pub const GET_PHYS_STATE: usize = 0xDC_CEC0;
+
+    /// Установить physics state.
+    /// Проверяет текущий, если отличается → provider->vtable[52].
+    /// IDA: `0x140DCD100`
+    pub const SET_PHYS_STATE: usize = 0xDC_D100;
+}
+
+/// Значения PhysicsState
+pub mod physics_state {
+    pub const DYNAMIC: u32 = 0;
+    pub const ENABLE: u32 = 1;
+    pub const DISABLED: u32 = 2;
+    pub const KINEMATIC: u32 = 3;
+}

--- a/sdk/src/addresses/globals.rs
+++ b/sdk/src/addresses/globals.rs
@@ -166,3 +166,31 @@ pub const RENDER_MAX_TEXTURE_SIZE_REMOTE: usize = 0x1C3_58A0;
 ///
 /// IDA: `0x1431430F0` (`M2DE_g_CameraManager`)
 pub const CAMERA_MANAGER: usize = 0x314_30F0;
+
+/// `g_M2DE_PlayerData` — глобальная структура настроек здоровья игрока.
+///
+/// Важно: это НЕ указатель — прямой объект в `.data` секции.
+/// Доступ: `module_base + PLAYER_DATA`, без разыменования.
+///
+/// Содержит:
+/// - `+0x00`: float healthmax (default 520.0, runtime 720.0 на нормальной сложности)
+/// - `+0x04`: float healthmaxvar (200.0)
+/// - `+0x14`: float healthrestoredown_raw (~0.0175, Lua возвращает *100)
+/// - `+0x18`: float boostfall (2.0)
+/// - `+0x1C`: float healthmax_threshold (520.0, для статистики)
+///
+/// Максимум здоровья игрока читается из +0x00, а НЕ из entity+0x14C.
+/// NPC используют entity+0x14C для своего healthmax.
+///
+/// IDA: `0x141CA1B38`
+pub const PLAYER_DATA: usize = 0x1CA_1B38;
+
+/// `g_M2DE_PhysicsWorldManager` — менеджер физического мира.
+///
+/// Важно: Двойная косвенность: *(module_base + RVA) → PhysicsWorldManager*
+///
+/// Содержит список физических объектов.
+/// Используется PlayerActor_GetPosition в режиме 3.
+///
+/// IDA: `0x141CABDC8`
+pub const PHYSICS_WORLD_MANAGER: usize = 0x1CA_BDC8;

--- a/sdk/src/game/player.rs
+++ b/sdk/src/game/player.rs
@@ -422,6 +422,178 @@ impl Player {
     }
 
     // ═══════════════════════════════════════════════════════════════
+    //  Патроны
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Включить/выключить бесконечные патроны.
+    pub fn set_unlimited_ammo(&self, enabled: bool) -> bool {
+        let Some(inv) = self.inventory_ptr() else {
+            logger::error("set_unlimited_ammo: инвентарь NULL");
+            return false;
+        };
+        unsafe { memory::write_value(inv + fields::inventory::UNLIMITED_AMMO, enabled as u8) }
+    }
+
+    /// Проверить, включены ли бесконечные патроны.
+    pub fn is_unlimited_ammo(&self) -> Option<bool> {
+        let inv = self.inventory_ptr()?;
+        unsafe { memory::read_value::<u8>(inv + fields::inventory::UNLIMITED_AMMO).map(|v| v != 0) }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Оружие в руках
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Проверить, есть ли оружие в руках.
+    pub fn has_weapon_in_hand(&self) -> Option<bool> {
+        unsafe {
+            let ws = memory::read_ptr(self.ptr + fields::player::WEAPON_STATE_COMPONENT)?;
+            let weapon_data = memory::read_ptr_raw(ws + fields::weapon_state::CURRENT_WEAPON_DATA)?;
+            Some(weapon_data != 0)
+        }
+    }
+
+    /// Получить ID оружия в руках (None = руки пусты).
+    pub fn get_weapon_in_hand_id(&self) -> Option<u32> {
+        unsafe {
+            let ws = memory::read_ptr(self.ptr + fields::player::WEAPON_STATE_COMPONENT)?;
+            let weapon_data = memory::read_ptr(ws + fields::weapon_state::CURRENT_WEAPON_DATA)?;
+            memory::read_value::<u32>(weapon_data + fields::weapon_data::WEAPON_ID)
+        }
+    }
+
+    /// Проверить, огнестрельное ли оружие в руках.
+    pub fn has_fire_weapon_in_hand(&self) -> Option<bool> {
+        unsafe {
+            let ws = memory::read_ptr(self.ptr + fields::player::WEAPON_STATE_COMPONENT)?;
+            let weapon_data = memory::read_ptr(ws + fields::weapon_state::CURRENT_WEAPON_DATA)?;
+            let flags = memory::read_value::<u32>(weapon_data + fields::weapon_data::WEAPON_FLAGS)?;
+            Some((flags & fields::weapon_type_flags::FIRE_WEAPON) != 0)
+        }
+    }
+
+    /// Получить текущие патроны в обойме оружия в руках.
+    pub fn get_current_ammo(&self) -> Option<i32> {
+        unsafe {
+            let ws = memory::read_ptr(self.ptr + fields::player::WEAPON_STATE_COMPONENT)?;
+            let weapon_data = memory::read_ptr(ws + fields::weapon_state::CURRENT_WEAPON_DATA)?;
+            let container = memory::read_ptr(weapon_data + fields::weapon_data::AMMO_CONTAINER)?;
+            let value_store = memory::read_ptr(container + 0x10)?;
+            memory::read_value::<i32>(value_store + 0x10)
+        }
+    }
+
+    /// Проверить, холодное ли оружие в руках (нож, бита).
+    pub fn has_cold_weapon_in_hand(&self) -> Option<bool> {
+        unsafe {
+            let ws = memory::read_ptr(self.ptr + fields::player::WEAPON_STATE_COMPONENT)?;
+            let wd = memory::read_ptr(ws + fields::weapon_state::CURRENT_WEAPON_DATA)?;
+            let flags = memory::read_value::<u32>(wd + fields::weapon_data::WEAPON_FLAGS)?;
+            Some((flags & fields::weapon_type_flags::COLD_WEAPON) != 0)
+        }
+    }
+
+    /// Проверить, метательное ли оружие в руках (граната, молотов).
+    pub fn has_throwing_weapon_in_hand(&self) -> Option<bool> {
+        unsafe {
+            let ws = memory::read_ptr(self.ptr + fields::player::WEAPON_STATE_COMPONENT)?;
+            let wd = memory::read_ptr(ws + fields::weapon_state::CURRENT_WEAPON_DATA)?;
+            let flags = memory::read_value::<u32>(wd + fields::weapon_data::WEAPON_FLAGS)?;
+            Some((flags & fields::weapon_type_flags::THROWING_WEAPON) != 0)
+        }
+    }
+
+    /// Проверить, пусты ли руки.
+    pub fn has_empty_hands(&self) -> Option<bool> {
+        self.has_weapon_in_hand().map(|has| !has)
+    }
+
+    /// Получить тип оружия в руках как строку (для отладки).
+    pub fn get_weapon_type_str(&self) -> &'static str {
+        if self.has_fire_weapon_in_hand().unwrap_or(false) {
+            "огнестрельное"
+        } else if self.has_cold_weapon_in_hand().unwrap_or(false) {
+            "холодное"
+        } else if self.has_throwing_weapon_in_hand().unwrap_or(false) {
+            "метательное"
+        } else if self.has_weapon_in_hand().unwrap_or(false) {
+            "неизвестное"
+        } else {
+            "пусто"
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Physics State
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Получить текущее состояние физики.
+    pub fn get_phys_state(&self) -> Option<u32> {
+        unsafe {
+            let physics = memory::read_ptr(self.ptr + fields::player::PHYSICS_PROVIDER)?;
+            let vtable = memory::read_ptr(physics)?;
+            let func_ptr = memory::read_ptr(vtable + 53 * 8)?;
+            type GetStateFn = unsafe extern "C" fn(usize) -> u32;
+            let func: GetStateFn = std::mem::transmute(func_ptr);
+            Some(func(physics))
+        }
+    }
+
+    /// Установить состояние физики.
+    /// Безопасный путь через движковую функцию.
+    pub fn set_phys_state(&self, state: u32) -> bool {
+        let Some(prop_acc) = (unsafe { memory::read_ptr(self.ptr + fields::player::CONTROL_COMPONENT) }) else {
+            return false;
+        };
+
+        type SetPhysStateFn = unsafe extern "C" fn(usize, u32) -> u64;
+        let func: SetPhysStateFn = unsafe {
+            memory::fn_at(base() + addresses::functions::physics::SET_PHYS_STATE)
+        };
+
+        unsafe { func(prop_acc, state) };
+        true
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Direction basis from frame matrix
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Получить forward-вектор персонажа (куда смотрит, в плоскости XY).
+    pub fn get_forward(&self) -> Option<Vec3> {
+        unsafe {
+            let frame = memory::read_ptr_raw(self.ptr + fields::player::FRAME_NODE)?;
+            if frame == 0 { return None; }
+            // Col1 = Forward
+            let x = memory::read_value::<f32>(frame + fields::entity_frame::FORWARD_X)?;
+            let y = memory::read_value::<f32>(frame + fields::entity_frame::FORWARD_Y)?;
+            let z = memory::read_value::<f32>(frame + fields::entity_frame::FORWARD_Z)?;
+            if x.is_finite() && y.is_finite() && z.is_finite() {
+                Some(Vec3 { x, y, z })
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Получить right-вектор персонажа (направление вправо).
+    pub fn get_right(&self) -> Option<Vec3> {
+        unsafe {
+            let frame = memory::read_ptr_raw(self.ptr + fields::player::FRAME_NODE)?;
+            if frame == 0 { return None; }
+            // Col0 = Right
+            let x = memory::read_value::<f32>(frame + fields::entity_frame::RIGHT_X)?;
+            let y = memory::read_value::<f32>(frame + fields::entity_frame::RIGHT_Y)?;
+            let z = memory::read_value::<f32>(frame + fields::entity_frame::RIGHT_Z)?;
+            if x.is_finite() && y.is_finite() && z.is_finite() {
+                Some(Vec3 { x, y, z })
+            } else {
+                None
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
     //  Управление (блокировка, стиль)
     // ═══════════════════════════════════════════════════════════════
 
@@ -549,6 +721,165 @@ impl Player {
     }
 
     // ═══════════════════════════════════════════════════════════════
+    //  Здоровье
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Получить текущее здоровье.
+    /// 720.0 = полное на нормальной сложности.
+    pub fn get_health(&self) -> Option<f32> {
+        unsafe { memory::read_value::<f32>(self.ptr + fields::player::CURRENT_HEALTH) }
+    }
+
+    /// Установить текущее здоровье напрямую.
+    ///
+    /// Если поставить <= 0.0 — персонаж НЕ умрёт автоматически,
+    /// смерть тригерится только из кода урона. Для убийства
+    /// используй Lua `healthrel = 0`.
+    pub fn set_health(&self, value: f32) -> bool {
+        unsafe { memory::write_value(self.ptr + fields::player::CURRENT_HEALTH, value) }
+    }
+
+    /// Получить максимум здоровья игрока.
+    /// Читает из глобальной структуры g_M2DE_PlayerData+0x00.
+    /// НЕ из entity — у игрока healthmax хранится отдельно.
+    pub fn get_health_max(&self) -> Option<f32> {
+        unsafe {
+            let player_data = base() + addresses::globals::PLAYER_DATA;
+            memory::read_value::<f32>(player_data)
+        }
+    }
+
+    /// Установить максимум здоровья игрока.
+    /// Пишет в g_M2DE_PlayerData+0x00.
+    pub fn set_health_max(&self, value: f32) -> bool {
+        unsafe {
+            let player_data = base() + addresses::globals::PLAYER_DATA;
+            memory::write_value(player_data, value)
+        }
+    }
+
+    /// Полностью восстановить здоровье до максимума.
+    pub fn heal_full(&self) -> bool {
+        match self.get_health_max() {
+            Some(max_hp) => self.set_health(max_hp),
+            None => {
+                // Фоллбек: на нормальной сложности максимум 720
+                logger::warn("heal_full: не удалось прочитать healthmax, ставлю 720.0");
+                self.set_health(720.0)
+            }
+        }
+    }
+
+    /// Добавить здоровье (не выше максимума).
+    pub fn add_health(&self, amount: f32) -> Option<f32> {
+        let current = self.get_health()?;
+        let max_hp = self.get_health_max().unwrap_or(720.0);
+        let new_hp = (current + amount).min(max_hp).max(0.0);
+        self.set_health(new_hp);
+        Some(new_hp)
+    }
+
+    /// Получить здоровье в процентах (0.0 — 100.0).
+    pub fn get_health_percent(&self) -> Option<f32> {
+        let current = self.get_health()?;
+        let max_hp = self.get_health_max().unwrap_or(720.0);
+        if max_hp > 0.0 {
+            Some((current / max_hp) * 100.0)
+        } else {
+            Some(0.0)
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Флаги: неуязвимость, полубог, смерть
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Жив ли игрок.
+    pub fn is_alive(&self) -> Option<bool> {
+        unsafe { memory::read_value::<u8>(self.ptr + fields::player::IS_DEAD).map(|v| v == 0) }
+    }
+
+    /// Проверить флаг неуязвимости.
+    pub fn is_invulnerable(&self) -> Option<bool> {
+        unsafe {
+            memory::read_value::<u8>(self.ptr + fields::player::INVULNERABILITY)
+                .map(|v| v != 0)
+        }
+    }
+
+    /// Установить/снять неуязвимость.
+    /// При включённой неуязвимости весь урон пропускается.
+    pub fn set_invulnerable(&self, enabled: bool) -> bool {
+        unsafe {
+            memory::write_value(self.ptr + fields::player::INVULNERABILITY, enabled as u8)
+        }
+    }
+
+    /// Проверить режим полубога.
+    pub fn is_demigod(&self) -> Option<bool> {
+        unsafe { memory::read_value::<u8>(self.ptr + fields::player::DEMIGOD).map(|v| v != 0) }
+    }
+
+    /// Установить/снять режим полубога.
+    /// При полубоге здоровье не падает ниже 1.0 — персонаж
+    /// получает урон, но не умирает.
+    pub fn set_demigod(&self, enabled: bool) -> bool {
+        unsafe { memory::write_value(self.ptr + fields::player::DEMIGOD, enabled as u8) }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  God Mode (комбинированный)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Включить/выключить режим бога.
+    ///
+    /// Включает:
+    /// 1. Неуязвимость (пропускает урон полностью)
+    /// 2. Полубог (запасной — если неуязвимость сбросится)
+    /// 3. Полное восстановление здоровья
+    pub fn set_god_mode(&self, enabled: bool) -> bool {
+        let ok1 = self.set_invulnerable(enabled);
+        let ok2 = self.set_demigod(enabled);
+
+        if enabled {
+            self.heal_full();
+        }
+
+        if ok1 && ok2 {
+            logger::info(&format!(
+                "God Mode: {}",
+                if enabled { "ВКЛЮЧЁН" } else { "ВЫКЛЮЧЕН" }
+            ));
+            true
+        } else {
+            logger::error("God Mode: не удалось записать флаги");
+            false
+        }
+    }
+
+    /// Проверить, активен ли God Mode.
+    pub fn is_god_mode(&self) -> bool {
+        self.is_invulnerable().unwrap_or(false) && self.is_demigod().unwrap_or(false)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Транспорт
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Проверить, находится ли игрок в транспорте.
+    pub fn is_in_vehicle(&self) -> Option<bool> {
+        unsafe {
+            memory::read_ptr_raw(self.ptr + fields::player::OWNER)
+                .map(|owner| owner != 0)
+        }
+    }
+
+    /// Получить указатель на текущий транспорт (или None если пешком).
+    pub fn get_vehicle_ptr(&self) -> Option<usize> {
+        unsafe { memory::read_ptr(self.ptr + fields::player::OWNER) }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
     //  Диагностика
     // ═══════════════════════════════════════════════════════════════
 
@@ -598,6 +929,23 @@ impl Player {
                 }
             }
             None => logger::debug("  Инвентарь: NULL"),
+        }
+    }
+    /// Вывести информацию об оружии в руках.
+    pub fn log_weapon_info(&self) {
+        match self.get_weapon_in_hand_id() {
+            Some(id) => {
+                let ammo = self.get_current_ammo().unwrap_or(-1);
+                let is_fire = self.has_fire_weapon_in_hand().unwrap_or(false);
+                let unlimited = self.is_unlimited_ammo().unwrap_or(false);
+                logger::info(&format!(
+                    "[weapon] ID={} | Патроны={} | Огнестрельное={} | Бесконечные={}",
+                    id, ammo, is_fire, unlimited
+                ));
+            }
+            None => {
+                logger::info("[weapon] Руки пусты");
+            }
         }
     }
 }

--- a/sdk/src/structures/player.rs
+++ b/sdk/src/structures/player.rs
@@ -1,34 +1,183 @@
-//! Структура игрока (C_Human).
+//! Структура игрока (C_Human / C_Player).
+//!
+//! Все поля восстановлены из IDA Pro + runtime проверок.
+//! Процент уверенности указан в комментариях к каждому полю.
 
 use std::ffi::c_void;
 use super::Inventory;
 use crate::macros::assert_field_offsets;
 
-/// Игрок (наследует Entity).
+/// Игрок (C_Human / C_Player).
 ///
 /// Движок использует C_Human для всех humanoid-сущностей.
-/// Для локального игрока указатель берётся из GameManager.
+/// Для локального игрока (entity_type=0x10) указатель
+/// берётся из GameManager+0x180.
 ///
-/// Основные поля:
-/// - `frame_node` — transform node с матрицей 4x4 (позиция мира)
-/// - `inventory` — инвентарь с оружием и деньгами
-/// - `control_component` — управление (блокировка, стиль)
+/// vtable: 0x14184C060 (игрок), 0x1418E5188 (NPC)
+///
+/// Ключевые подтверждённые поля:
+/// - `frame_node` (+0x78) — transform node с матрицей (позиция мира)
+/// - `owner` (+0x80) — NULL пешком, vehicle* в машине
+/// - `inventory` (+0xE8) — инвентарь с оружием и деньгами
+/// - `current_health` (+0x148) — текущее здоровье (float)
+/// - `invulnerability` (+0x160) — флаг неуязвимости
+/// - `is_dead` (+0x161) — флаг смерти
+/// - `demigod` (+0x162) — флаг полубога
+/// - `self_ref` (+0x190) — указатель на самого себя (валидация)
 #[repr(C)]
 pub struct CHuman {
-    pub vtable: *const c_void,          // +0x00
-    _pad_008: [u8; 0x78 - 0x08],
+    // === Базовый C_Entity ===
+
+    /// Указатель на vtable
+    pub vtable: *const c_void,                   // +0x000
+    /// Связи в графе сцены (linked list).
+    _scene_graph: [u8; 0x1C],                    // +0x008..+0x024
+    /// Тип сущности: 0x10=игрок, 0x0E=NPC, 0x12=физ. тело
+    pub entity_type: u8,                         // +0x024
+    _pad_025: [u8; 0x03],                        // +0x025
+    /// Флаги сущности (бит 15 меняется при смене состояния)
+    pub entity_flags: u32,                       // +0x028
+    _pad_02C: [u8; 0x0C],                        // +0x02C
+    /// GUID сущности (16 байт)
+    pub guid: [u8; 16],                          // +0x038
+    _entity_pad: [u8; 0x30],                     // +0x048..+0x078
+
+    // === C_Actor ===
+
     /// Frame/transform node — хранит мировую позицию.
-    /// Координаты: frame+0x64 (X), frame+0x74 (Y), frame+0x84 (Z).
-    pub frame_node: *mut c_void,        // +0x78
-    _pad_080: [u8; 0xE8 - 0x80],
-    /// Инвентарь игрока (оружие, деньги, предметы).
-    pub inventory: *mut Inventory,      // +0xE8
-    /// Компонент управления (блокировка ввода, стиль боя).
-    pub control_component: *mut c_void, // +0xF0
+    /// Координаты: frame+0x64 (X), frame+0x74 (Y), frame+0x84 (Z)
+    pub frame_node: *mut c_void,                 // +0x078
+    /// Владелец: NULL пешком, vehicle* в машине
+    pub owner: *mut c_void,                      // +0x080
+
+    // === Указатели на компоненты (inline внутри C_Human) ===
+
+    /// Пустые слоты (всегда 0)
+    _slots_088: [u8; 0x18],                      // +0x088..+0x0A0
+    /// Подтип сущности (= 6 для человека)
+    pub entity_subtype: u32,                     // +0x0A0
+    _pad_0A4: u32,                               // +0x0A4
+    _component_0A8: *mut c_void,                 // +0x0A8
+    _entity_id_hash: u32,                        // +0x0B0
+    _pad_0B4: u32,                               // +0x0B4
+    _component_0B8: *mut c_void,                 // +0x0B8
+    /// AI/навигационный компонент (vtbl 0x1418E3290)
+    pub ai_nav: *mut c_void,                     // +0x0C0
+    _component_0C8: *mut c_void,                 // +0x0C8
+    /// Компонент синхронизации позиции (vtbl 0x1418E33A8)
+    pub transform_sync: *mut c_void,             // +0x0D0
+    /// Опциональный компонент, создаётся по запросу (msg 0xD0059)
+    pub optional_component: *mut c_void,         // +0x0D8
+    _component_0E0: *mut c_void,                 // +0x0E0
+    /// Инвентарь (оружие, деньги, предметы). vtbl 0x1418E3090
+    pub inventory: *mut Inventory,               // +0x0E8
+    /// Property accessor — первый qword = back-ref на self (НЕ vtable!)
+    pub property_accessor: *mut c_void,          // +0x0F0
+    /// Behavior компонент — сюда пересылаются сообщения. vtbl 0x1418E37A8
+    pub behavior: *mut c_void,                   // +0x0F8
+    _component_100: *mut c_void,                 // +0x100
+    /// Компонент состояния оружия. *(this + 0x2B0) → ID оружия
+    pub weapon_state: *mut c_void,               // +0x108
+    _components_110: [u8; 0x18],                 // +0x110..+0x128
+    _pad_128: [u8; 0x18],                        // +0x128..+0x140
+
+    // === Здоровье и урон ===
+
+    /// Сущность крепления к транспорту (set/clear по msg 0x50002)
+    pub vehicle_mount: *mut c_void,              // +0x140
+    /// Текущее здоровье. 720.0 = полное (нормальная сложность)
+    pub current_health: f32,                     // +0x148
+    /// NPC: максимум здоровья. Игрок: множитель типов урона 12/15/22
+    pub npc_healthmax_or_type_mult: f32,         // +0x14C
+    /// Множитель урона от NPC (Lua: *100 = проценты). Default 1.0
+    pub nonplayer_damage_mult: f32,              // +0x150
+    /// Пороговая дистанция для снижения урона. Default 5.0
+    pub nonplayer_damage_dist: f32,              // +0x154
+    _pad_158: [u8; 0x08],                        // +0x158..+0x160
+
+    // === Флаги состояния ===
+
+    /// Неуязвимость. 0=обычный, 1=неуязвим (урон полностью пропускается)
+    pub invulnerability: u8,                     // +0x160
+    /// Флаг смерти. IsDeath() = return *(this + 0x161)
+    pub is_dead: u8,                             // +0x161
+    /// Режим полубога. Здоровье не падает ниже 1.0 при уроне
+    pub demigod: u8,                             // +0x162
+    _pad_163: [u8; 0x1D],                        // +0x163..+0x180
+
+    // === Урон по частям тела ===
+
+    /// Массив множителей урона: [4]=голова, [5]=торс, [6]=руки, [7]=ноги.
+    pub body_damage_multipliers: *mut f32,       // +0x180
+    _pad_188: [u8; 0x08],                        // +0x188
+
+    // === Ссылка на себя ===
+
+    /// Указатель на самого себя. Валидация: self_ref == this.
+    pub self_ref: *mut CHuman,                   // +0x190
 }
 
 assert_field_offsets!(CHuman {
-    frame_node        == 0x78,
-    inventory         == 0xE8,
-    control_component == 0xF0,
+    vtable                     == 0x000,
+    entity_type                == 0x024,
+    entity_flags               == 0x028,
+    guid                       == 0x038,
+    frame_node                 == 0x078,
+    owner                      == 0x080,
+    entity_subtype             == 0x0A0,
+    ai_nav                     == 0x0C0,
+    transform_sync             == 0x0D0,
+    optional_component         == 0x0D8,
+    inventory                  == 0x0E8,
+    property_accessor          == 0x0F0,
+    behavior                   == 0x0F8,
+    weapon_state               == 0x108,
+    vehicle_mount              == 0x140,
+    current_health             == 0x148,
+    npc_healthmax_or_type_mult == 0x14C,
+    nonplayer_damage_mult      == 0x150,
+    nonplayer_damage_dist      == 0x154,
+    invulnerability            == 0x160,
+    is_dead                    == 0x161,
+    demigod                    == 0x162,
+    body_damage_multipliers    == 0x180,
+    self_ref                   == 0x190,
 });
+
+impl CHuman {
+    /// Текущее здоровье.
+    pub fn health(&self) -> f32 {
+        self.current_health
+    }
+
+    /// Жив ли персонаж.
+    pub fn is_alive(&self) -> bool {
+        self.is_dead == 0
+    }
+
+    /// Проверка флага неуязвимости.
+    pub fn is_invulnerable(&self) -> bool {
+        self.invulnerability != 0
+    }
+
+    /// Проверка режима полубога.
+    pub fn is_demigod(&self) -> bool {
+        self.demigod != 0
+    }
+
+    /// Находится ли в транспорте.
+    pub fn is_in_vehicle(&self) -> bool {
+        !self.owner.is_null()
+    }
+
+    /// Является ли это игроком (а не NPC).
+    pub fn is_player(&self) -> bool {
+        self.entity_type == 0x10
+    }
+
+    /// Валидация указателя через self_ref.
+    pub fn is_valid_ptr(&self) -> bool {
+        let self_ptr = self as *const Self;
+        self.self_ref == self_ptr as *mut CHuman
+    }
+}


### PR DESCRIPTION
…data

Deep structural reverse of C_Human player entity and related subsystems:

Health & Combat:
- player+0x148: float current_health (runtime confirmed, 720.0 = full)
- player+0x14C: NPC healthmax / player damage type multiplier
- player+0x150: nonplayerdamage multiplier (Lua * 100)
- player+0x154: nonplayerdamagedist threshold
- player+0x160: uint8 invulnerability flag
- player+0x161: uint8 is_dead flag (IsDeath vtable[47])
- player+0x162: uint8 demigod flag (prevents death, clamps HP to 1.0)
- player+0x180: float* body damage multipliers [4]=head [5]=torso [6]=arms [7]=legs
- player+0x338: Vec3 death position
- player+0x344: int32 death type (1=normal, 128=explosion)
- full damage flow reconstruction: physics → damage calc → death

Global Player Data:
- g_M2DE_PlayerData (0x141CA1B38): healthmax, healthmaxvar, boostfall, healthrestoredown, healthmax_threshold
- healthmax for player reads from global, NOT entity+0x14C
- healthfall and healthrestore are stubs (return 0.0) in DE

Lua Property System:
- located property table at 0x141C74A50 for C_WrapperHuman
- mapped all health-related getters/setters: invulnerability, health, healthmax, healthmaxvar, healthfall, boostfall, healthrestore, healthrestoredown, nonplayerdamage, nonplayerdamagedist
- confirmed property accessor pattern: entity+0xF0 → back-ref → field

Inventory:
- inventory+0x08: RB-tree for weapon lookup by ID
- inventory+0x168: bool unlimited_ammo
- slot layout: [0]=current weapon, [2]=weapon slot 1, [3]=weapon slot 2, [4]=ammo reserve, [5]=money
- slot+0x50: weapon table entry pointer
- weapon table: +0x24=flags (bit1=slot assignment), +0x58=max ammo
- reload flow: slot[0] weapon → table max → slot[4] ammo → transfer
- holster: player sends message 0xD0055, NPC writes behavior+0x248

Weapon State Component (player+0x108):
- *(component+0x2B0): ptr to current weapon data in hand (NULL=empty)
- weapon_data+0x00: weapon_id, +0x24: weapon_flags
- weapon_flags bits: 0x04=cold, 0x20=fire, 0x200000=throwing
- ammo stored via container pattern: *(*(inner+0x10)+0x10) = int32 ammo

Entity Structure:
- player+0x024: uint8 entity_type (0x10=player, 0x0E=NPC, 0x12=physics)
- player+0x028: uint32 entity_flags
- player+0x038: GUID (16 bytes)
- player+0x0C0: AI/nav component (vtbl 0x1418E3290)
- player+0x0D0: TransformSync component (vtbl 0x1418E33A8, NOT health)
- player+0x0D8: optional component (allocated on demand)
- player+0x0F0: property accessor (back-ref pattern for Lua)
- player+0x0F8: behavior component (message forwarding target)
- player+0x140: vehicle mount entity (msg 0x50002)
- player+0x190: self_ref (== this, for pointer validation)

Frame/Transform Matrix (runtime confirmed):
- 4x4 matrix at frame+0x58, position in last column
- Col0 (+0x58/+0x68/+0x78) = Right vector
- Col1 (+0x5C/+0x6C/+0x7C) = Forward vector (character facing)
- Col2 (+0x60/+0x70/+0x80) = Up vector (world Z)
- Col3 (+0x64/+0x74/+0x84) = Position (confirmed earlier)

Physics:
- player+0x258: PhysicsProvider (vtbl 0x141993998, heap-allocated)
- GetPhysState: provider→vtable[53], SetPhysState: provider→vtable[52]
- g_PhysicsWorldManager at 0x141CABDC8
- physics object internal matrix: obj[6]=X, obj[10]=Y, obj[14]=Z

Vtable Analysis (0x14184C060):
- [47] = IsDeath (return *(this+0x161))
- [50] = Character Update (main per-frame)
- [65] = PlayerActor_GetPosition (source of truth)
- [82] = ProcessDamage (entry point for damage chain)
- three confirmed vtables: C_Actor abstract, C_Human/Player, C_HumanNPC

Message System:
- new confirmed messages: HEAD_DAMAGE(0xD0041), BODY_DAMAGE(0xD0042), KILL_DAMAGE(0xD0043), HOLSTER_WEAPON(0xD0055)
- PHYSICS_DAMAGE(0x50001): incoming from physics, triggers damage chain
- VEHICLE_OWNERSHIP(0x50002): set/clear vehicle mount

Practical implementations:
- Player::get/set_health(), heal_full(), get_health_percent()
- Player::set_invulnerable(), set_demigod(), set_god_mode()
- Player::set_unlimited_ammo()
- Player::has_fire/cold/throwing_weapon_in_hand()
- Player::get_weapon_in_hand_id(), get_current_ammo()
- Player::get_forward(), get_right() from frame matrix
- Player::is_in_vehicle(), get_vehicle_ptr()
- Noclip/fly mode with direction-aware movement and vehicle teleport